### PR TITLE
fix: Path Traversal 취약점 수정 (#12)

### DIFF
--- a/api/src/main/java/com/hopenvision/exam/controller/JsonImportController.java
+++ b/api/src/main/java/com/hopenvision/exam/controller/JsonImportController.java
@@ -77,8 +77,23 @@ public class JsonImportController {
             @Parameter(description = "답안지 JSON 파일명 (upload 폴더 내)")
             @RequestParam String answerFileName) {
 
-        Path questionFilePath = Paths.get(uploadPath, questionFileName);
-        Path answerFilePath = Paths.get(uploadPath, answerFileName);
+        Path uploadDir = Paths.get(uploadPath).toAbsolutePath().normalize();
+        Path questionFilePath = uploadDir.resolve(questionFileName).normalize();
+        Path answerFilePath = uploadDir.resolve(answerFileName).normalize();
+
+        if (!questionFilePath.startsWith(uploadDir)) {
+            throw new IllegalArgumentException("잘못된 파일 경로입니다: 문제지 파일명에 경로 탐색 문자를 사용할 수 없습니다.");
+        }
+        if (!answerFilePath.startsWith(uploadDir)) {
+            throw new IllegalArgumentException("잘못된 파일 경로입니다: 답안지 파일명에 경로 탐색 문자를 사용할 수 없습니다.");
+        }
+
+        if (!questionFilePath.getFileName().toString().toLowerCase().endsWith(".json")) {
+            throw new IllegalArgumentException("문제지는 JSON 파일만 허용됩니다 (.json)");
+        }
+        if (!answerFilePath.getFileName().toString().toLowerCase().endsWith(".json")) {
+            throw new IllegalArgumentException("답안지는 JSON 파일만 허용됩니다 (.json)");
+        }
 
         if (!questionFilePath.toFile().exists()) {
             throw new IllegalArgumentException("문제지 파일을 찾을 수 없습니다: " + questionFileName);


### PR DESCRIPTION
## Summary
- `JsonImportController.importFromUploadFolder()` 메서드에서 사용자 입력 파일명에 대한 Path Traversal 방지 검증 추가
- `Path.normalize()` + `startsWith()` 조합으로 upload 디렉토리 외부 접근 차단
- JSON 확장자 화이트리스트 검증 추가

## Test plan
- [ ] `questionFileName=../../etc/passwd` 등 경로 탐색 문자 포함 시 400 에러 반환 확인
- [ ] 정상 JSON 파일명으로 import 시 기존 기능 정상 동작 확인
- [ ] `./gradlew test` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)