### PR TITLE
feat: Spring Security 인증 + Bean Validation 강화

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // Database
     runtimeOnly 'org.postgresql:postgresql'

--- a/api/src/main/java/com/hopenvision/config/SecurityConfig.java
+++ b/api/src/main/java/com/hopenvision/config/SecurityConfig.java
@@ -1,0 +1,92 @@
+package com.hopenvision.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Value("${app.admin.api-key:}")
+    private String adminApiKey;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                // Swagger/OpenAPI - 허용
+                .requestMatchers("/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
+                // 사용자 시험 응시 API - 허용 (X-User-Id 헤더 검증은 컨트롤러에서)
+                .requestMatchers("/api/user/**").permitAll()
+                // 통계 조회 - 허용
+                .requestMatchers(HttpMethod.GET, "/api/statistics/**").permitAll()
+                // 관리자 API - API Key 필수
+                .requestMatchers(HttpMethod.POST, "/api/**").authenticated()
+                .requestMatchers(HttpMethod.PUT, "/api/**").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/api/**").authenticated()
+                // GET 요청 - 허용
+                .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
+                .anyRequest().permitAll()
+            )
+            .addFilterBefore(new ApiKeyAuthFilter(adminApiKey), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    /**
+     * API Key 인증 필터
+     * X-Api-Key 헤더 또는 Authorization: Bearer <key> 헤더로 인증
+     */
+    static class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+        private final String apiKey;
+
+        ApiKeyAuthFilter(String apiKey) {
+            this.apiKey = apiKey;
+        }
+
+        @Override
+        protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                        FilterChain filterChain) throws ServletException, IOException {
+            // API key가 설정되지 않은 경우 모든 요청 허용 (개발 환경)
+            if (apiKey == null || apiKey.isBlank()) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            String requestApiKey = request.getHeader("X-Api-Key");
+            if (requestApiKey == null) {
+                String authHeader = request.getHeader("Authorization");
+                if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                    requestApiKey = authHeader.substring(7);
+                }
+            }
+
+            if (apiKey.equals(requestApiKey)) {
+                var auth = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                        "admin", null,
+                        java.util.List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_ADMIN"))
+                );
+                org.springframework.security.core.context.SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/api/src/main/java/com/hopenvision/exam/dto/AnswerKeyDto.java
+++ b/api/src/main/java/com/hopenvision/exam/dto/AnswerKeyDto.java
@@ -1,5 +1,7 @@
 package com.hopenvision.exam.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -14,11 +16,19 @@ public class AnswerKeyDto {
     @AllArgsConstructor
     @Builder
     public static class Request {
+        @Size(max = 50, message = "시험코드는 50자 이내입니다")
         private String examCd;
+        @Size(max = 50, message = "과목코드는 50자 이내입니다")
         private String subjectCd;
+        @Min(value = 1, message = "문항번호는 1 이상입니다")
+        @Max(value = 999, message = "문항번호는 999 이하입니다")
         private Integer questionNo;
+        @Size(max = 100, message = "정답은 100자 이내입니다")
         private String correctAns;
+        @DecimalMin(value = "0", message = "배점은 0 이상입니다")
+        @DecimalMax(value = "1000", message = "배점은 1000 이하입니다")
         private BigDecimal score;
+        @Size(max = 1, message = "복수정답여부는 1자입니다")
         private String isMultiAns;
     }
 
@@ -28,8 +38,14 @@ public class AnswerKeyDto {
     @AllArgsConstructor
     @Builder
     public static class BulkRequest {
+        @NotBlank(message = "시험코드는 필수입니다")
+        @Size(max = 50, message = "시험코드는 50자 이내입니다")
         private String examCd;
+        @NotBlank(message = "과목코드는 필수입니다")
+        @Size(max = 50, message = "과목코드는 50자 이내입니다")
         private String subjectCd;
+        @NotNull(message = "정답 목록은 필수입니다")
+        @Valid
         private List<AnswerItem> answers;
     }
 
@@ -39,9 +55,14 @@ public class AnswerKeyDto {
     @AllArgsConstructor
     @Builder
     public static class AnswerItem {
+        @NotNull(message = "문항번호는 필수입니다")
+        @Min(value = 1, message = "문항번호는 1 이상입니다")
         private Integer questionNo;
+        @Size(max = 100, message = "정답은 100자 이내입니다")
         private String correctAns;
+        @DecimalMin(value = "0", message = "배점은 0 이상입니다")
         private BigDecimal score;
+        @Size(max = 1, message = "복수정답여부는 1자입니다")
         private String isMultiAns;
     }
 

--- a/api/src/main/java/com/hopenvision/exam/dto/ApplicantDto.java
+++ b/api/src/main/java/com/hopenvision/exam/dto/ApplicantDto.java
@@ -1,6 +1,6 @@
 package com.hopenvision.exam.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -15,12 +15,19 @@ public class ApplicantDto {
     @Builder
     public static class Request {
         @NotBlank(message = "수험번호는 필수입니다")
+        @Size(min = 1, max = 20, message = "수험번호는 1~20자입니다")
         private String applicantNo;
+        @Size(max = 50, message = "사용자ID는 50자 이내입니다")
         private String userId;
         @NotBlank(message = "이름은 필수입니다")
+        @Size(min = 1, max = 100, message = "이름은 1~100자입니다")
         private String userNm;
+        @Size(max = 50, message = "응시지역은 50자 이내입니다")
         private String applyArea;
+        @Size(max = 20, message = "응시유형은 20자 이내입니다")
         private String applyType;
+        @DecimalMin(value = "0", message = "가산점은 0 이상입니다")
+        @DecimalMax(value = "100", message = "가산점은 100 이하입니다")
         private BigDecimal addScore;
     }
 

--- a/api/src/main/java/com/hopenvision/exam/dto/ExamDto.java
+++ b/api/src/main/java/com/hopenvision/exam/dto/ExamDto.java
@@ -1,6 +1,7 @@
 package com.hopenvision.exam.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -17,17 +18,29 @@ public class ExamDto {
     @Builder
     public static class Request {
         @NotBlank(message = "시험코드는 필수입니다")
+        @Size(min = 1, max = 50, message = "시험코드는 1~50자입니다")
         private String examCd;
         @NotBlank(message = "시험명은 필수입니다")
+        @Size(min = 1, max = 200, message = "시험명은 1~200자입니다")
         private String examNm;
         @NotBlank(message = "시험유형은 필수입니다")
+        @Size(max = 20, message = "시험유형은 20자 이내입니다")
         private String examType;
+        @Size(max = 4, message = "시험연도는 4자 이내입니다")
         private String examYear;
+        @Min(value = 1, message = "회차는 1 이상입니다")
+        @Max(value = 99, message = "회차는 99 이하입니다")
         private Integer examRound;
         private LocalDate examDate;
+        @DecimalMin(value = "0", message = "총점은 0 이상입니다")
+        @DecimalMax(value = "10000", message = "총점은 10000 이하입니다")
         private BigDecimal totalScore;
+        @DecimalMin(value = "0", message = "합격점수는 0 이상입니다")
+        @DecimalMax(value = "10000", message = "합격점수는 10000 이하입니다")
         private BigDecimal passScore;
+        @Size(max = 1, message = "사용여부는 1자입니다")
         private String isUse;
+        @Valid
         private List<SubjectDto.Request> subjects;
     }
 

--- a/api/src/main/java/com/hopenvision/exam/dto/SubjectDto.java
+++ b/api/src/main/java/com/hopenvision/exam/dto/SubjectDto.java
@@ -1,5 +1,6 @@
 package com.hopenvision.exam.dto;
 
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -14,15 +15,28 @@ public class SubjectDto {
     @AllArgsConstructor
     @Builder
     public static class Request {
+        @Size(max = 50, message = "시험코드는 50자 이내입니다")
         private String examCd;
+        @Size(max = 50, message = "과목코드는 50자 이내입니다")
         private String subjectCd;
+        @Size(max = 200, message = "과목명은 200자 이내입니다")
         private String subjectNm;
+        @Size(max = 20, message = "과목유형은 20자 이내입니다")
         private String subjectType;
+        @Min(value = 1, message = "문항수는 1 이상입니다")
+        @Max(value = 999, message = "문항수는 999 이하입니다")
         private Integer questionCnt;
+        @DecimalMin(value = "0", message = "배점은 0 이상입니다")
+        @DecimalMax(value = "1000", message = "배점은 1000 이하입니다")
         private BigDecimal scorePerQ;
+        @Size(max = 20, message = "문항유형은 20자 이내입니다")
         private String questionType;
+        @DecimalMin(value = "0", message = "과락점수는 0 이상입니다")
         private BigDecimal cutLine;
+        @Min(value = 0, message = "정렬순서는 0 이상입니다")
+        @Max(value = 999, message = "정렬순서는 999 이하입니다")
         private Integer sortOrder;
+        @Size(max = 1, message = "사용여부는 1자입니다")
         private String isUse;
     }
 

--- a/api/src/main/java/com/hopenvision/user/controller/UserExamController.java
+++ b/api/src/main/java/com/hopenvision/user/controller/UserExamController.java
@@ -12,8 +12,11 @@ import com.hopenvision.user.service.UserScoringService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -27,57 +30,67 @@ public class UserExamController {
     private final UserScoringService userScoringService;
     private final ScoreAnalysisService scoreAnalysisService;
 
+    private static final java.util.regex.Pattern USER_ID_PATTERN =
+            java.util.regex.Pattern.compile("^[a-zA-Z0-9_-]{1,50}$");
+
+    private String validateUserId(String userId) {
+        if (userId == null || userId.isBlank() || !USER_ID_PATTERN.matcher(userId).matches()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 ID 형식입니다");
+        }
+        return userId;
+    }
+
     @GetMapping("/exams")
     @Operation(summary = "채점 가능한 시험 목록 조회")
     public ApiResponse<List<UserExamDto>> getAvailableExams(
-            @Parameter(description = "사용자 ID (임시)", example = "user001")
+            @Parameter(description = "사용자 ID", example = "user001")
             @RequestHeader(value = "X-User-Id", defaultValue = "guest") String userId) {
-        return ApiResponse.success(userExamService.getAvailableExams(userId));
+        return ApiResponse.success(userExamService.getAvailableExams(validateUserId(userId)));
     }
 
     @GetMapping("/exams/{examCd}")
     @Operation(summary = "시험 상세 조회")
     public ApiResponse<UserExamDto> getExamDetail(
-            @Parameter(description = "사용자 ID (임시)")
+            @Parameter(description = "사용자 ID")
             @RequestHeader(value = "X-User-Id", defaultValue = "guest") String userId,
             @PathVariable String examCd) {
-        return ApiResponse.success(userExamService.getExamDetail(userId, examCd));
+        return ApiResponse.success(userExamService.getExamDetail(validateUserId(userId), examCd));
     }
 
     @PostMapping("/exams/{examCd}/submit")
     @Operation(summary = "답안 제출 및 채점")
     public ApiResponse<ScoringResultDto> submitAnswers(
-            @Parameter(description = "사용자 ID (임시)")
+            @Parameter(description = "사용자 ID")
             @RequestHeader(value = "X-User-Id", defaultValue = "guest") String userId,
             @PathVariable String examCd,
-            @RequestBody UserAnswerDto.SubmitRequest request) {
+            @Valid @RequestBody UserAnswerDto.SubmitRequest request) {
         request.setExamCd(examCd);
-        return ApiResponse.success(userScoringService.submitAndScore(userId, request));
+        return ApiResponse.success(userScoringService.submitAndScore(validateUserId(userId), request));
     }
 
     @GetMapping("/exams/{examCd}/result")
     @Operation(summary = "내 채점 결과 조회")
     public ApiResponse<ScoringResultDto> getMyResult(
-            @Parameter(description = "사용자 ID (임시)")
+            @Parameter(description = "사용자 ID")
             @RequestHeader(value = "X-User-Id", defaultValue = "guest") String userId,
             @PathVariable String examCd) {
-        return ApiResponse.success(userScoringService.getMyScore(userId, examCd));
+        return ApiResponse.success(userScoringService.getMyScore(validateUserId(userId), examCd));
     }
 
     @GetMapping("/exams/{examCd}/analysis")
     @Operation(summary = "성적 비교/분석 조회")
     public ApiResponse<ScoreAnalysisDto> getScoreAnalysis(
-            @Parameter(description = "사용자 ID (임시)")
+            @Parameter(description = "사용자 ID")
             @RequestHeader(value = "X-User-Id", defaultValue = "guest") String userId,
             @PathVariable String examCd) {
-        return ApiResponse.success(scoreAnalysisService.getScoreAnalysis(userId, examCd));
+        return ApiResponse.success(scoreAnalysisService.getScoreAnalysis(validateUserId(userId), examCd));
     }
 
     @GetMapping("/history")
     @Operation(summary = "채점 이력 조회")
     public ApiResponse<List<HistoryDto.HistoryItem>> getUserHistory(
-            @Parameter(description = "사용자 ID (임시)")
+            @Parameter(description = "사용자 ID")
             @RequestHeader(value = "X-User-Id", defaultValue = "guest") String userId) {
-        return ApiResponse.success(userExamService.getUserHistory(userId));
+        return ApiResponse.success(userExamService.getUserHistory(validateUserId(userId)));
     }
 }

--- a/api/src/main/java/com/hopenvision/user/dto/UserAnswerDto.java
+++ b/api/src/main/java/com/hopenvision/user/dto/UserAnswerDto.java
@@ -1,5 +1,7 @@
 package com.hopenvision.user.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
 import java.util.List;
@@ -24,7 +26,12 @@ public class UserAnswerDto {
     @AllArgsConstructor
     @Builder
     public static class SubmitRequest {
+        @NotBlank(message = "시험코드는 필수입니다")
+        @Size(max = 50, message = "시험코드는 50자 이내입니다")
         private String examCd;
+        @NotNull(message = "과목 답안 목록은 필수입니다")
+        @Size(min = 1, message = "최소 1개 과목의 답안이 필요합니다")
+        @Valid
         private List<SubjectAnswer> subjects;
     }
 
@@ -34,7 +41,11 @@ public class UserAnswerDto {
     @AllArgsConstructor
     @Builder
     public static class SubjectAnswer {
+        @NotBlank(message = "과목코드는 필수입니다")
+        @Size(max = 50, message = "과목코드는 50자 이내입니다")
         private String subjectCd;
+        @NotNull(message = "답안 목록은 필수입니다")
+        @Valid
         private List<QuestionAnswer> answers;
     }
 
@@ -44,7 +55,10 @@ public class UserAnswerDto {
     @AllArgsConstructor
     @Builder
     public static class QuestionAnswer {
+        @NotNull(message = "문항번호는 필수입니다")
+        @Min(value = 1, message = "문항번호는 1 이상입니다")
         private Integer questionNo;
+        @Size(max = 100, message = "답안은 100자 이내입니다")
         private String answer;
     }
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -46,6 +46,11 @@ springdoc:
 cors:
   allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:5173}
 
+# Admin API Key 인증
+app:
+  admin:
+    api-key: ${ADMIN_API_KEY:}
+
 # 로깅 설정
 logging:
   level:


### PR DESCRIPTION
## Summary
- Spring Security 도입: API Key 기반 관리자 인증 (POST/PUT/DELETE 엔드포인트)
- 모든 DTO에 Bean Validation 제약조건 추가 (@Size, @Min, @Max, @DecimalMin 등)
- UserExamController: X-User-Id 헤더 형식 검증 (영문숫자 1~50자)
- ADMIN_API_KEY 환경변수 미설정 시 개발 모드 허용

## Test plan
- [ ] ADMIN_API_KEY 설정 후 POST /api/exams 호출 시 401 응답 확인
- [ ] X-Api-Key 헤더 포함 시 정상 동작 확인
- [ ] GET /api/user/exams 인증 없이 정상 접근 가능 확인
- [ ] 잘못된 형식의 DTO 전송 시 400 Validation 에러 확인
- [ ] X-User-Id에 특수문자 포함 시 400 에러 확인

fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)