### PR TITLE
perf: N+1 쿼리 제거 + 점수 분포 DB 집계 전환 (fixes #14)

### DIFF
--- a/api/src/main/java/com/hopenvision/exam/repository/ExamRepository.java
+++ b/api/src/main/java/com/hopenvision/exam/repository/ExamRepository.java
@@ -47,4 +47,11 @@ public interface ExamRepository extends JpaRepository<Exam, String> {
     // 시험별 응시자 수 조회
     @Query("SELECT COUNT(a) FROM ExamApplicant a WHERE a.examCd = :examCd")
     long countApplicantsByExamCd(@Param("examCd") String examCd);
+
+    // 시험 목록 + 과목/응시자 카운트 일괄 조회 (N+1 방지)
+    @Query("SELECT e.examCd, " +
+           "(SELECT COUNT(s) FROM ExamSubject s WHERE s.examCd = e.examCd), " +
+           "(SELECT COUNT(a) FROM ExamApplicant a WHERE a.examCd = e.examCd) " +
+           "FROM Exam e WHERE e.examCd IN :examCds")
+    List<Object[]> findExamCountsByExamCds(@Param("examCds") List<String> examCds);
 }

--- a/api/src/main/java/com/hopenvision/user/repository/UserScoreRepository.java
+++ b/api/src/main/java/com/hopenvision/user/repository/UserScoreRepository.java
@@ -38,4 +38,9 @@ public interface UserScoreRepository extends JpaRepository<UserScore, UserScoreI
 
     @Query("SELECT COUNT(us) FROM UserScore us WHERE us.id.examCd = :examCd AND us.id.subjectCd = :subjectCd AND us.rawScore > :score")
     Long countByExamCdAndSubjectCdAndScoreGreaterThan(@Param("examCd") String examCd, @Param("subjectCd") String subjectCd, @Param("score") java.math.BigDecimal score);
+
+    // 과목별 통계 일괄 조회 (N+1 방지)
+    @Query("SELECT us.id.subjectCd, COUNT(us), AVG(us.rawScore), MAX(us.rawScore), MIN(us.rawScore) " +
+           "FROM UserScore us WHERE us.id.examCd = :examCd GROUP BY us.id.subjectCd")
+    List<Object[]> getSubjectStatsBatch(@Param("examCd") String examCd);
 }

--- a/api/src/main/java/com/hopenvision/user/repository/UserTotalScoreRepository.java
+++ b/api/src/main/java/com/hopenvision/user/repository/UserTotalScoreRepository.java
@@ -44,4 +44,19 @@ public interface UserTotalScoreRepository extends JpaRepository<UserTotalScore, 
 
     @Query("SELECT uts FROM UserTotalScore uts WHERE uts.userId = :userId ORDER BY uts.regDt DESC")
     List<UserTotalScore> findByUserIdOrderByRegDtDesc(@Param("userId") String userId);
+
+    // 점수 분포 계산 (DB에서 직접 집계)
+    @Query("SELECT " +
+           "SUM(CASE WHEN uts.totalScore >= 90 THEN 1 ELSE 0 END), " +
+           "SUM(CASE WHEN uts.totalScore >= 80 AND uts.totalScore < 90 THEN 1 ELSE 0 END), " +
+           "SUM(CASE WHEN uts.totalScore >= 70 AND uts.totalScore < 80 THEN 1 ELSE 0 END), " +
+           "SUM(CASE WHEN uts.totalScore >= 60 AND uts.totalScore < 70 THEN 1 ELSE 0 END), " +
+           "SUM(CASE WHEN uts.totalScore >= 50 AND uts.totalScore < 60 THEN 1 ELSE 0 END), " +
+           "SUM(CASE WHEN uts.totalScore >= 40 AND uts.totalScore < 50 THEN 1 ELSE 0 END), " +
+           "SUM(CASE WHEN uts.totalScore >= 30 AND uts.totalScore < 40 THEN 1 ELSE 0 END), " +
+           "SUM(CASE WHEN uts.totalScore >= 20 AND uts.totalScore < 30 THEN 1 ELSE 0 END), " +
+           "SUM(CASE WHEN uts.totalScore >= 10 AND uts.totalScore < 20 THEN 1 ELSE 0 END), " +
+           "SUM(CASE WHEN uts.totalScore < 10 THEN 1 ELSE 0 END) " +
+           "FROM UserTotalScore uts WHERE uts.examCd = :examCd AND uts.totalScore IS NOT NULL")
+    Object[] getScoreDistribution(@Param("examCd") String examCd);
 }


### PR DESCRIPTION
## Summary
- 시험 목록 조회 N+1 (페이지당 2N개 COUNT) → 배치 서브쿼리 1회로 통합
- 점수 분포 계산: 전체 데이터 메모리 로딩 → DB `CASE WHEN` 단일 집계 쿼리
- 과목별 통계: 과목당 4개 쿼리 (4N) → `GROUP BY` 단일 쿼리 1회

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `ExamRepository` | `findExamCountsByExamCds` 배치 카운트 쿼리 추가 |
| `ExamService` | `getExamList()` 배치 카운트 적용 |
| `StatisticsService` | 점수 분포 DB 집계 + 과목별 GROUP BY |
| `UserTotalScoreRepository` | `getScoreDistribution()` CASE WHEN 쿼리 추가 |
| `UserScoreRepository` | `getSubjectStatsBatch()` GROUP BY 쿼리 추가 |

## Performance Impact
- 시험 목록 (10건 페이지): 21쿼리 → 2쿼리 (90% 감소)
- 통계 조회 (10과목): 40+쿼리 → 3쿼리 (92% 감소)
- 점수 분포: 10,000건 메모리 로딩 → 0건 (메모리 100% 절감)

## Test plan
- [ ] `GET /api/exams` 시험 목록 subjectCnt/applicantCnt 정상 반환 확인
- [ ] `GET /api/exams/{examCd}/statistics` 점수 분포/과목별 통계 정상 확인
- [ ] `POST /api/exams` 시험 등록 후 카운트 반영 확인
- [ ] `./gradlew test` 단위 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)