### PR TITLE
feat: Optimistic Locking + 감사 로깅 + 에러 ID 추적

### DIFF
--- a/api/src/main/java/com/hopenvision/config/AuditListener.java
+++ b/api/src/main/java/com/hopenvision/config/AuditListener.java
@@ -1,0 +1,53 @@
+package com.hopenvision.config;
+
+import jakarta.persistence.*;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * JPA Entity 감사 로깅 리스너
+ * Entity CRUD 이벤트를 감지하여 로깅합니다.
+ */
+@Slf4j
+public class AuditListener {
+
+    @PostPersist
+    public void onPostPersist(Object entity) {
+        log.info("[AUDIT] CREATE entity={} id={}", entity.getClass().getSimpleName(), getEntityId(entity));
+    }
+
+    @PostUpdate
+    public void onPostUpdate(Object entity) {
+        log.info("[AUDIT] UPDATE entity={} id={}", entity.getClass().getSimpleName(), getEntityId(entity));
+    }
+
+    @PostRemove
+    public void onPostRemove(Object entity) {
+        log.info("[AUDIT] DELETE entity={} id={}", entity.getClass().getSimpleName(), getEntityId(entity));
+    }
+
+    private String getEntityId(Object entity) {
+        try {
+            var idField = findIdField(entity.getClass());
+            if (idField != null) {
+                idField.setAccessible(true);
+                Object id = idField.get(entity);
+                return id != null ? id.toString() : "null";
+            }
+        } catch (Exception e) {
+            // ignore
+        }
+        return "unknown";
+    }
+
+    private java.lang.reflect.Field findIdField(Class<?> clazz) {
+        for (var field : clazz.getDeclaredFields()) {
+            if (field.isAnnotationPresent(Id.class) || field.isAnnotationPresent(EmbeddedId.class)) {
+                return field;
+            }
+        }
+        if (clazz.getSuperclass() != null) {
+            return findIdField(clazz.getSuperclass());
+        }
+        return null;
+    }
+}

--- a/api/src/main/java/com/hopenvision/config/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/hopenvision/config/GlobalExceptionHandler.java
@@ -2,13 +2,16 @@ package com.hopenvision.config;
 
 import com.hopenvision.exam.dto.ApiResponse;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.OptimisticLockException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
@@ -39,10 +42,19 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(message));
     }
 
+    @ExceptionHandler({OptimisticLockException.class, ObjectOptimisticLockingFailureException.class})
+    public ResponseEntity<ApiResponse<Void>> handleOptimisticLock(Exception e) {
+        String errorId = UUID.randomUUID().toString().substring(0, 8);
+        log.warn("[{}] Optimistic Lock Conflict: {}", errorId, e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error("다른 사용자가 동시에 수정했습니다. 새로고침 후 다시 시도해주세요. (오류 ID: " + errorId + ")"));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        log.error("Internal Error: {}", e.getMessage(), e);
+        String errorId = UUID.randomUUID().toString().substring(0, 8);
+        log.error("[{}] Internal Error: {}", errorId, e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error("서버 오류가 발생했습니다."));
+                .body(ApiResponse.error("서버 오류가 발생했습니다. (오류 ID: " + errorId + ")"));
     }
 }

--- a/api/src/main/java/com/hopenvision/exam/entity/Exam.java
+++ b/api/src/main/java/com/hopenvision/exam/entity/Exam.java
@@ -1,5 +1,6 @@
 package com.hopenvision.exam.entity;
 
+import com.hopenvision.config.AuditListener;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -13,6 +14,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "exam_mst")
+@EntityListeners(AuditListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -57,6 +59,11 @@ public class Exam {
     @UpdateTimestamp
     @Column(name = "upd_dt")
     private LocalDateTime updDt;
+
+    @Version
+    @Column(name = "version")
+    @Builder.Default
+    private Long version = 0L;
 
     @OneToMany(mappedBy = "exam", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default


### PR DESCRIPTION
## Summary
- Exam 엔티티에 `@Version` 컬럼 추가 (Optimistic Locking 동시성 제어)
- `AuditListener` 구현 (`@EntityListeners` - CREATE/UPDATE/DELETE 감사 로깅)
- `GlobalExceptionHandler`에 `OptimisticLockException` 핸들링 (409 Conflict)
- 에러 응답에 UUID 기반 에러 ID 추가 (로그 추적 가능)
- ExcelImportService 감사 로깅 강화

Fixes #15

## Test plan
- [ ] Exam CRUD 시 version 컬럼 자동 증가 확인
- [ ] 동시 수정 시 409 Conflict 에러 반환 확인
- [ ] 에러 응답에 오류 ID 포함 확인
- [ ] 로그에 [AUDIT] CREATE/UPDATE/DELETE 이벤트 기록 확인
- [ ] Excel import 시 감사 로그 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)