### PR TITLE
feat: 사용자 프로필 팝업 구현

### DIFF
--- a/api/src/main/java/com/hopenvision/user/controller/UserProfileController.java
+++ b/api/src/main/java/com/hopenvision/user/controller/UserProfileController.java
@@ -1,0 +1,61 @@
+package com.hopenvision.user.controller;
+
+import com.hopenvision.exam.dto.ApiResponse;
+import com.hopenvision.user.dto.UserProfileDto;
+import com.hopenvision.user.service.UserProfileService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/user/profile")
+@RequiredArgsConstructor
+@Tag(name = "사용자 - 프로필", description = "사용자 프로필 관리 API")
+public class UserProfileController {
+
+    private final UserProfileService userProfileService;
+
+    private static final java.util.regex.Pattern USER_ID_PATTERN =
+            java.util.regex.Pattern.compile("^[a-zA-Z0-9_-]{1,50}$");
+
+    private String validateUserId(String userId) {
+        if (userId == null || userId.isBlank() || !USER_ID_PATTERN.matcher(userId).matches()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 ID 형식입니다");
+        }
+        return userId;
+    }
+
+    @GetMapping
+    @Operation(summary = "내 프로필 조회")
+    public ApiResponse<UserProfileDto.Response> getProfile(
+            @Parameter(description = "사용자 ID", example = "user001")
+            @RequestHeader(value = "X-User-Id", defaultValue = "guest") String userId) {
+        return ApiResponse.success(userProfileService.getProfile(validateUserId(userId)));
+    }
+
+    @GetMapping("/exists")
+    @Operation(summary = "프로필 존재 여부 확인")
+    public ApiResponse<Boolean> hasProfile(
+            @Parameter(description = "사용자 ID", example = "user001")
+            @RequestHeader(value = "X-User-Id", defaultValue = "guest") String userId) {
+        return ApiResponse.success(userProfileService.hasProfile(validateUserId(userId)));
+    }
+
+    @PostMapping
+    @Operation(summary = "프로필 생성/수정")
+    public ApiResponse<UserProfileDto.Response> upsertProfile(
+            @Parameter(description = "사용자 ID", example = "user001")
+            @RequestHeader(value = "X-User-Id", defaultValue = "guest") String userId,
+            @Valid @RequestBody UserProfileDto.UpsertRequest request) {
+        String validatedUserId = validateUserId(userId);
+        if (!validatedUserId.equals(request.getUserId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "헤더의 사용자 ID와 요청 본문의 사용자 ID가 일치하지 않습니다");
+        }
+        return ApiResponse.success(userProfileService.upsertProfile(request));
+    }
+}

--- a/api/src/main/java/com/hopenvision/user/dto/UserProfileDto.java
+++ b/api/src/main/java/com/hopenvision/user/dto/UserProfileDto.java
@@ -1,0 +1,48 @@
+package com.hopenvision.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class UserProfileDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String userId;
+        private String userNm;
+        private String email;
+        private String newsletterYn;
+        private LocalDateTime regDt;
+        private LocalDateTime updDt;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpsertRequest {
+        @NotBlank(message = "사용자 ID는 필수입니다")
+        @Size(min = 1, max = 50, message = "사용자 ID는 1~50자입니다")
+        private String userId;
+
+        @NotBlank(message = "이름은 필수입니다")
+        @Size(min = 1, max = 100, message = "이름은 1~100자입니다")
+        private String userNm;
+
+        @Email(message = "올바른 이메일 형식이 아닙니다")
+        @Size(max = 200, message = "이메일은 200자 이내입니다")
+        private String email;
+
+        @Pattern(regexp = "^[YN]$", message = "뉴스레터 수신 여부는 Y 또는 N입니다")
+        private String newsletterYn;
+    }
+}

--- a/api/src/main/java/com/hopenvision/user/entity/UserProfile.java
+++ b/api/src/main/java/com/hopenvision/user/entity/UserProfile.java
@@ -1,0 +1,44 @@
+package com.hopenvision.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_profile")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfile {
+
+    @Id
+    @Column(name = "user_id", length = 50)
+    private String userId;
+
+    @Column(name = "user_nm", length = 100, nullable = false)
+    private String userNm;
+
+    @Column(name = "email", length = 200)
+    private String email;
+
+    @Column(name = "newsletter_yn", length = 1)
+    @Builder.Default
+    private String newsletterYn = "N";
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @CreationTimestamp
+    @Column(name = "reg_dt", updatable = false)
+    private LocalDateTime regDt;
+
+    @UpdateTimestamp
+    @Column(name = "upd_dt")
+    private LocalDateTime updDt;
+}

--- a/api/src/main/java/com/hopenvision/user/repository/UserProfileRepository.java
+++ b/api/src/main/java/com/hopenvision/user/repository/UserProfileRepository.java
@@ -1,0 +1,7 @@
+package com.hopenvision.user.repository;
+
+import com.hopenvision.user.entity.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, String> {
+}

--- a/api/src/main/java/com/hopenvision/user/service/UserProfileService.java
+++ b/api/src/main/java/com/hopenvision/user/service/UserProfileService.java
@@ -1,0 +1,58 @@
+package com.hopenvision.user.service;
+
+import com.hopenvision.user.dto.UserProfileDto;
+import com.hopenvision.user.entity.UserProfile;
+import com.hopenvision.user.repository.UserProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserProfileService {
+
+    private final UserProfileRepository userProfileRepository;
+
+    @Transactional(readOnly = true)
+    public UserProfileDto.Response getProfile(String userId) {
+        return userProfileRepository.findById(userId)
+                .map(this::toResponse)
+                .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasProfile(String userId) {
+        return userProfileRepository.existsById(userId);
+    }
+
+    @Transactional
+    public UserProfileDto.Response upsertProfile(UserProfileDto.UpsertRequest request) {
+        UserProfile profile = userProfileRepository.findById(request.getUserId())
+                .map(existing -> {
+                    existing.setUserNm(request.getUserNm());
+                    existing.setEmail(request.getEmail());
+                    existing.setNewsletterYn(request.getNewsletterYn() != null ? request.getNewsletterYn() : "N");
+                    return existing;
+                })
+                .orElseGet(() -> UserProfile.builder()
+                        .userId(request.getUserId())
+                        .userNm(request.getUserNm())
+                        .email(request.getEmail())
+                        .newsletterYn(request.getNewsletterYn() != null ? request.getNewsletterYn() : "N")
+                        .build());
+
+        UserProfile saved = userProfileRepository.save(profile);
+        return toResponse(saved);
+    }
+
+    private UserProfileDto.Response toResponse(UserProfile entity) {
+        return UserProfileDto.Response.builder()
+                .userId(entity.getUserId())
+                .userNm(entity.getUserNm())
+                .email(entity.getEmail())
+                .newsletterYn(entity.getNewsletterYn())
+                .regDt(entity.getRegDt())
+                .updDt(entity.getUpdDt())
+                .build();
+    }
+}

--- a/web/src/api/userApi.ts
+++ b/web/src/api/userApi.ts
@@ -1,21 +1,25 @@
 import client from './client';
 import type {
   UserExam,
+  UserProfile,
   ScoringResult,
   ScoreAnalysis,
   HistoryItem,
   SubmitRequest,
+  UserProfileUpsertRequest,
   UserExamListResponse,
   UserExamDetailResponse,
   ScoringResultResponse,
   ScoreAnalysisResponse,
   HistoryListResponse,
+  UserProfileResponse,
+  UserProfileExistsResponse,
 } from '../types/user';
 
 const USER_ID_HEADER = 'X-User-Id';
 
 // 사용자 ID 가져오기 (임시로 localStorage 사용)
-const getUserId = (): string => {
+export const getUserId = (): string => {
   return localStorage.getItem('userId') || 'guest';
 };
 
@@ -73,5 +77,33 @@ export const getUserHistory = async (): Promise<HistoryItem[]> => {
   const response = await client.get<HistoryListResponse>('/api/user/history', {
     headers: { [USER_ID_HEADER]: getUserId() },
   });
+  return response.data.data;
+};
+
+// 내 프로필 조회
+export const getMyProfile = async (): Promise<UserProfile | null> => {
+  const response = await client.get<UserProfileResponse>('/api/user/profile', {
+    headers: { [USER_ID_HEADER]: getUserId() },
+  });
+  return response.data.data;
+};
+
+// 프로필 존재 여부 확인
+export const hasProfile = async (): Promise<boolean> => {
+  const response = await client.get<UserProfileExistsResponse>('/api/user/profile/exists', {
+    headers: { [USER_ID_HEADER]: getUserId() },
+  });
+  return response.data.data;
+};
+
+// 프로필 생성/수정
+export const upsertProfile = async (request: UserProfileUpsertRequest): Promise<UserProfile> => {
+  const response = await client.post<UserProfileResponse>(
+    '/api/user/profile',
+    request,
+    {
+      headers: { [USER_ID_HEADER]: request.userId },
+    }
+  );
   return response.data.data;
 };

--- a/web/src/components/UserProfileModal.tsx
+++ b/web/src/components/UserProfileModal.tsx
@@ -1,0 +1,113 @@
+import { useEffect } from 'react';
+import { Modal, Form, Input, Checkbox, message } from 'antd';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { upsertProfile, setUserId } from '../api/userApi';
+import type { UserProfile, UserProfileUpsertRequest } from '../types/user';
+
+interface UserProfileModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSaved?: (userId: string) => void;
+  profile: UserProfile | null;
+  userId: string;
+  isFirstTime: boolean;
+}
+
+export default function UserProfileModal({ open, onClose, onSaved, profile, userId, isFirstTime }: UserProfileModalProps) {
+  const [form] = Form.useForm();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (open) {
+      form.setFieldsValue({
+        userId: profile?.userId || userId,
+        userNm: profile?.userNm || '',
+        email: profile?.email || '',
+        newsletterYn: profile?.newsletterYn === 'Y',
+      });
+    }
+  }, [open, profile, userId, form]);
+
+  const mutation = useMutation({
+    mutationFn: upsertProfile,
+    onSuccess: (_data, variables) => {
+      if (isFirstTime) {
+        setUserId(variables.userId);
+      }
+      message.success(isFirstTime ? '프로필이 등록되었습니다.' : '프로필이 수정되었습니다.');
+      queryClient.invalidateQueries({ queryKey: ['userProfile'] });
+      queryClient.invalidateQueries({ queryKey: ['userProfileExists'] });
+      onSaved?.(variables.userId);
+      onClose();
+    },
+    onError: () => {
+      message.error('프로필 저장에 실패했습니다.');
+    },
+  });
+
+  const handleOk = () => {
+    form.validateFields().then((values) => {
+      const request: UserProfileUpsertRequest = {
+        userId: values.userId,
+        userNm: values.userNm,
+        email: values.email || undefined,
+        newsletterYn: values.newsletterYn ? 'Y' : 'N',
+      };
+      mutation.mutate(request);
+    });
+  };
+
+  const handleCancel = () => {
+    if (isFirstTime) {
+      Modal.confirm({
+        title: '프로필 등록을 건너뛰시겠습니까?',
+        content: '나중에 상단 프로필 버튼에서 등록할 수 있습니다.',
+        okText: '건너뛰기',
+        cancelText: '계속 작성',
+        onOk: onClose,
+      });
+    } else {
+      onClose();
+    }
+  };
+
+  return (
+    <Modal
+      title={isFirstTime ? '프로필 등록' : '프로필 수정'}
+      open={open}
+      onOk={handleOk}
+      onCancel={handleCancel}
+      okText="저장"
+      cancelText={isFirstTime ? '건너뛰기' : '취소'}
+      confirmLoading={mutation.isPending}
+      maskClosable={!isFirstTime}
+    >
+      <Form form={form} layout="vertical" style={{ marginTop: 16 }}>
+        <Form.Item
+          name="userId"
+          label="사용자 ID"
+          rules={[{ required: true, message: '사용자 ID를 입력하세요' }]}
+        >
+          <Input disabled={!isFirstTime} />
+        </Form.Item>
+        <Form.Item
+          name="userNm"
+          label="이름"
+          rules={[{ required: true, message: '이름을 입력하세요' }]}
+        >
+          <Input placeholder="이름을 입력하세요" />
+        </Form.Item>
+        <Form.Item
+          name="email"
+          label="이메일"
+          rules={[{ type: 'email', message: '올바른 이메일 형식이 아닙니다' }]}
+        >
+          <Input placeholder="이메일을 입력하세요 (선택)" />
+        </Form.Item>
+        <Form.Item name="newsletterYn" valuePropName="checked">
+          <Checkbox>뉴스레터 수신 동의</Checkbox>
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/web/src/pages/user/UserExamList.tsx
+++ b/web/src/pages/user/UserExamList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
@@ -7,11 +7,7 @@ import {
   Button,
   Space,
   Tag,
-  Input,
-  Modal,
-  Form,
   Typography,
-  message,
   Tooltip,
 } from 'antd';
 import {
@@ -20,7 +16,7 @@ import {
   UserOutlined,
   TrophyOutlined,
 } from '@ant-design/icons';
-import { getAvailableExams, setUserId } from '../../api/userApi';
+import { getAvailableExams } from '../../api/userApi';
 import type { UserExam } from '../../types/user';
 import { EXAM_TYPES } from '../../types/exam';
 
@@ -28,24 +24,11 @@ const { Title, Text } = Typography;
 
 const UserExamList: React.FC = () => {
   const navigate = useNavigate();
-  const [userIdModalVisible, setUserIdModalVisible] = useState(false);
-  const [form] = Form.useForm();
 
-  const currentUserId = localStorage.getItem('userId') || 'guest';
-
-  const { data: exams, isLoading, refetch } = useQuery({
+  const { data: exams, isLoading } = useQuery({
     queryKey: ['userExams'],
     queryFn: getAvailableExams,
   });
-
-  const handleUserIdChange = () => {
-    form.validateFields().then((values) => {
-      setUserId(values.userId);
-      message.success(`사용자 ID가 ${values.userId}로 변경되었습니다.`);
-      setUserIdModalVisible(false);
-      refetch();
-    });
-  };
 
   const getExamTypeLabel = (type: string) => {
     return EXAM_TYPES.find((t) => t.value === type)?.label || type;
@@ -158,23 +141,8 @@ const UserExamList: React.FC = () => {
   return (
     <div style={{ padding: 24 }}>
       <Card>
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
+        <div style={{ marginBottom: 16 }}>
           <Title level={4} style={{ margin: 0 }}>채점 가능한 시험 목록</Title>
-          <Space>
-            <Text type="secondary">현재 사용자:</Text>
-            <Tag color="blue" style={{ cursor: 'pointer' }} onClick={() => {
-              form.setFieldsValue({ userId: currentUserId });
-              setUserIdModalVisible(true);
-            }}>
-              {currentUserId}
-            </Tag>
-            <Button onClick={() => {
-              form.setFieldsValue({ userId: currentUserId });
-              setUserIdModalVisible(true);
-            }}>
-              변경
-            </Button>
-          </Space>
         </div>
 
         <Table
@@ -189,28 +157,6 @@ const UserExamList: React.FC = () => {
           }}
         />
       </Card>
-
-      <Modal
-        title="사용자 ID 설정"
-        open={userIdModalVisible}
-        onOk={handleUserIdChange}
-        onCancel={() => setUserIdModalVisible(false)}
-        okText="변경"
-        cancelText="취소"
-      >
-        <Form form={form} layout="vertical">
-          <Form.Item
-            name="userId"
-            label="사용자 ID"
-            rules={[{ required: true, message: '사용자 ID를 입력하세요' }]}
-          >
-            <Input placeholder="사용자 ID를 입력하세요" />
-          </Form.Item>
-        </Form>
-        <Text type="secondary">
-          * 실제 서비스에서는 로그인 기능으로 대체됩니다.
-        </Text>
-      </Modal>
     </div>
   );
 };

--- a/web/src/types/user.ts
+++ b/web/src/types/user.ts
@@ -121,9 +121,28 @@ export interface HistoryItem {
   regDt: string;
 }
 
+// 사용자 프로필
+export interface UserProfile {
+  userId: string;
+  userNm: string;
+  email: string | null;
+  newsletterYn: string;
+  regDt: string;
+  updDt: string;
+}
+
+export interface UserProfileUpsertRequest {
+  userId: string;
+  userNm: string;
+  email?: string;
+  newsletterYn: string;
+}
+
 // API Response 타입
 export type UserExamListResponse = ApiResponse<UserExam[]>;
 export type UserExamDetailResponse = ApiResponse<UserExam>;
 export type ScoringResultResponse = ApiResponse<ScoringResult>;
 export type ScoreAnalysisResponse = ApiResponse<ScoreAnalysis>;
 export type HistoryListResponse = ApiResponse<HistoryItem[]>;
+export type UserProfileResponse = ApiResponse<UserProfile>;
+export type UserProfileExistsResponse = ApiResponse<boolean>;


### PR DESCRIPTION
## Summary
- UserProfile 엔티티/API 신규 구현 (GET/POST /api/user/profile)
- Layout Header에 프로필 버튼 추가, 최초 접속 시 자동 등록 팝업 표시
- UserExamList의 userId 변경 모달을 Layout으로 이동하여 전역 관리

## Changes
### Backend (신규 5개 파일)
- `UserProfile.java` - JPA 엔티티 (@Version Optimistic Locking)
- `UserProfileDto.java` - Request/Response DTO (Bean Validation)
- `UserProfileRepository.java` - JPA Repository
- `UserProfileService.java` - getProfile, hasProfile, upsertProfile
- `UserProfileController.java` - REST API 3개 엔드포인트

### Frontend (신규 1개 + 수정 4개)
- `UserProfileModal.tsx` - 프로필 등록/수정 Modal 컴포넌트
- `Layout.tsx` - Header에 프로필 버튼/드롭다운 + 자동 팝업 로직
- `UserExamList.tsx` - userId 변경 모달 제거
- `user.ts` - UserProfile 타입 추가
- `userApi.ts` - 프로필 API 함수 3개 추가

## Test plan
- [ ] GET /api/user/profile/exists → 미등록 시 false
- [ ] POST /api/user/profile → 프로필 생성
- [ ] GET /api/user/profile → 프로필 조회
- [ ] 최초 접속 시 프로필 등록 팝업 자동 표시
- [ ] 프로필 저장 후 Header에 사용자 이름 표시
- [ ] Header 프로필 버튼 → 드롭다운 → 프로필 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)