### PR TITLE
chore: dev DB를 원격 PostgreSQL(hopenvision_dev)로 전환

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -85,20 +85,21 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
 
 ---
-# 개발 환경 (PostgreSQL)
+# 개발 환경 (원격 PostgreSQL - hopenvision_dev)
 spring:
   config:
     activate:
       on-profile: dev
 
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:172.30.1.72}:${DB_PORT:5432}/${DB_NAME:hopenvision_dev}
+    username: ${DB_USER:postgres}
+    password: ${DB_PASSWORD:}
+
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
-
-  sql:
-    init:
-      mode: always
 
 ---
 # 운영 환경

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:9050',
+        target: process.env.VITE_API_TARGET || 'http://localhost:8080',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- dev 프로필을 172.30.1.72/hopenvision_dev (원격 PostgreSQL)로 전환
- Vite 프록시 대상을 환경변수화하여 로컬 개발 시 포트 불일치 방지
- local 프로필(H2) 유지, prod 프로필(ddl-auto: none) 변경 없음

## Changes
- `application.yml`: dev 프로필 datasource를 172.30.1.72/hopenvision_dev로 변경, ddl-auto: update
- `vite.config.ts`: 프록시 대상을 `VITE_API_TARGET` 환경변수로 변경 (기본값 localhost:8080)

## 프로필 구조
| 프로필 | DB | DDL | 용도 |
|--------|-----|-----|------|
| local | H2 인메모리 | create | 오프라인 개발 |
| dev | 172.30.1.72/hopenvision_dev | update | 개발/테스트 |
| prod | Docker내부/hopenvision | none | 운영 |

## Test plan
- [x] dev 프로필 백엔드 시작 → 172.30.1.72 연결 성공
- [x] hopenvision_dev DB에 전체 테이블 자동 생성 확인
- [x] API CRUD 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)