### PR TITLE
feat: P1 이슈 5건 - HMAC 인증, 중복제출 방지, Swagger 제한, N+1 해결, DB 집계 (#25~#29)

### DIFF
--- a/api/src/main/java/com/hopenvision/exam/repository/ExamAnswerKeyRepository.java
+++ b/api/src/main/java/com/hopenvision/exam/repository/ExamAnswerKeyRepository.java
@@ -3,6 +3,8 @@ package com.hopenvision.exam.repository;
 import com.hopenvision.exam.entity.ExamAnswerKey;
 import com.hopenvision.exam.entity.ExamAnswerKeyId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -19,4 +21,7 @@ public interface ExamAnswerKeyRepository extends JpaRepository<ExamAnswerKey, Ex
     void deleteByExamCd(String examCd);
 
     long countByExamCdAndSubjectCd(String examCd, String subjectCd);
+
+    @Query("SELECT ak.subjectCd, COUNT(ak) FROM ExamAnswerKey ak WHERE ak.examCd = :examCd GROUP BY ak.subjectCd")
+    List<Object[]> countByExamCdGroupBySubject(@Param("examCd") String examCd);
 }

--- a/api/src/main/java/com/hopenvision/user/repository/UserTotalScoreRepository.java
+++ b/api/src/main/java/com/hopenvision/user/repository/UserTotalScoreRepository.java
@@ -15,6 +15,8 @@ public interface UserTotalScoreRepository extends JpaRepository<UserTotalScore, 
 
     Optional<UserTotalScore> findByUserIdAndExamCd(String userId, String examCd);
 
+    boolean existsByUserIdAndExamCd(String userId, String examCd);
+
     @Query("SELECT uts FROM UserTotalScore uts WHERE uts.examCd = :examCd ORDER BY uts.totalScore DESC")
     List<UserTotalScore> findByExamCdOrderByTotalScoreDesc(@Param("examCd") String examCd);
 

--- a/api/src/main/java/com/hopenvision/user/service/UserScoringService.java
+++ b/api/src/main/java/com/hopenvision/user/service/UserScoringService.java
@@ -36,6 +36,11 @@ public class UserScoringService {
     public ScoringResultDto submitAndScore(String userId, UserAnswerDto.SubmitRequest request) {
         String examCd = request.getExamCd();
 
+        // 0. 중복 제출 방지
+        if (userTotalScoreRepository.existsByUserIdAndExamCd(userId, examCd)) {
+            throw new IllegalStateException("이미 제출한 시험입니다: " + examCd);
+        }
+
         // 1. 시험 정보 조회
         Exam exam = examRepository.findById(examCd)
                 .orElseThrow(() -> new RuntimeException("시험을 찾을 수 없습니다: " + examCd));

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -50,6 +50,8 @@ cors:
 app:
   admin:
     api-key: ${ADMIN_API_KEY:}
+  user:
+    auth-secret: ${USER_AUTH_SECRET:}
 
 # 로깅 설정
 logging:
@@ -112,6 +114,12 @@ spring:
     hibernate:
       ddl-auto: none
     show-sql: false
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- X-User-Id 위변조 방어: HMAC 서명 검증 필터(UserIdAuthFilter) 도입
- 답안 재제출 Race Condition 방지: existsByUserIdAndExamCd 사전 확인
- Swagger 운영 노출 차단: prod 프로필에서 springdoc 비활성화
- ExamService N+1 쿼리 해결: 배치 카운트 쿼리(countByExamCdGroupBySubject) 도입
- ScoreAnalysis 메모리 로딩: DB CASE WHEN 집계 쿼리로 전환

## Related Issues
- Closes #25, Closes #26, Closes #27, Closes #28, Closes #29

## Test plan
- [ ] X-User-Id + X-User-Signature 서명 검증 동작 확인
- [ ] 동일 시험 중복 제출 시 에러 반환 확인
- [ ] prod 프로필에서 /swagger-ui 접근 불가 확인
- [ ] 시험 상세 조회 시 단일 쿼리로 과목별 answerCnt 조회 확인
- [ ] 점수 분포 조회 시 DB 집계 쿼리 사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)