### PR TITLE
chore: P3 코드 품질/인프라 개선 (#36~#39)

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -39,10 +39,6 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    // MapStruct (DTO 매핑)
-    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
-    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
-
     // Apache POI (Excel 파싱)
     implementation 'org.apache.poi:poi:5.2.5'
     implementation 'org.apache.poi:poi-ooxml:5.2.5'

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,40 +7,93 @@ echo ""
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_DIR"
 
-echo "[1/5] Pulling latest code from prod branch..."
+COMPOSE_FILE="docker-compose.prod.yml"
+HEALTH_RETRIES=5
+HEALTH_INTERVAL=15
+
+# 롤백용: 현재 이미지 ID 저장
+PREV_IMAGES=""
+save_current_images() {
+    PREV_IMAGES=$(docker compose -f "$COMPOSE_FILE" images -q 2>/dev/null || true)
+}
+
+health_check() {
+    local attempt=1
+    while [ $attempt -le $HEALTH_RETRIES ]; do
+        echo "  Health check attempt $attempt/$HEALTH_RETRIES..."
+        local fe_ok=false be_ok=false
+
+        if curl -f -s -o /dev/null --max-time 10 http://localhost:4060; then
+            fe_ok=true
+        fi
+        if curl -f -s -o /dev/null --max-time 10 "http://localhost:9050/api/exams?page=0&size=1"; then
+            be_ok=true
+        fi
+
+        if $fe_ok && $be_ok; then
+            echo "  Frontend (4060): OK"
+            echo "  Backend  (9050): OK"
+            return 0
+        fi
+
+        echo "  Frontend: $($fe_ok && echo OK || echo FAILED) | Backend: $($be_ok && echo OK || echo FAILED)"
+
+        if [ $attempt -lt $HEALTH_RETRIES ]; then
+            echo "  Retrying in ${HEALTH_INTERVAL}s..."
+            sleep $HEALTH_INTERVAL
+        fi
+        attempt=$((attempt + 1))
+    done
+    return 1
+}
+
+rollback() {
+    echo ""
+    echo "=== ROLLBACK: Health check failed, restoring previous version ==="
+    docker compose -f "$COMPOSE_FILE" down --timeout 30 || true
+
+    if [ -n "$PREV_IMAGES" ]; then
+        echo "  Restarting with previous images..."
+        docker compose -f "$COMPOSE_FILE" up -d
+        sleep 30
+        if health_check; then
+            echo "  Rollback succeeded."
+        else
+            echo "  WARNING: Rollback health check also failed. Manual intervention required."
+        fi
+    else
+        echo "  No previous images found. Manual intervention required."
+    fi
+    exit 1
+}
+
+echo "[1/6] Pulling latest code from prod branch..."
 git fetch origin
 git checkout prod
 git pull origin prod
 
-echo "[2/5] Stopping existing services..."
-docker compose -f docker-compose.prod.yml down --timeout 30 || true
+echo "[2/6] Saving current deployment state..."
+save_current_images
 
-echo "[3/5] Building Docker images..."
-docker compose -f docker-compose.prod.yml build --no-cache
+echo "[3/6] Stopping existing services..."
+docker compose -f "$COMPOSE_FILE" down --timeout 30 || true
 
-echo "[4/5] Starting services..."
-docker compose -f docker-compose.prod.yml up -d
+echo "[4/6] Building Docker images..."
+docker compose -f "$COMPOSE_FILE" build --no-cache
 
-echo "[5/5] Waiting for services to be ready..."
-sleep 60
+echo "[5/6] Starting services..."
+docker compose -f "$COMPOSE_FILE" up -d
 
-echo ""
-echo "=== Health Check ==="
-if curl -f -s -o /dev/null http://localhost:4060; then
-    echo "  Frontend (4060): OK"
+echo "[6/6] Running health checks (max ${HEALTH_RETRIES} attempts)..."
+sleep 30
+
+if health_check; then
+    echo ""
+    echo "=== Deployment Successful ==="
+    echo "  Frontend: http://localhost:4060"
+    echo "  Backend:  http://localhost:9050"
+    echo "  Database: localhost:5432"
+    exit 0
 else
-    echo "  Frontend (4060): FAILED"
+    rollback
 fi
-
-if curl -f -s -o /dev/null "http://localhost:9050/api/exams?page=0&size=1"; then
-    echo "  Backend  (9050): OK"
-else
-    echo "  Backend  (9050): FAILED"
-fi
-
-echo ""
-echo "=== Deployment Complete ==="
-echo "  Frontend: http://localhost:4060"
-echo "  Backend:  http://localhost:9050"
-echo "  Swagger:  http://localhost:4060/swagger-ui.html"
-echo "  Database: localhost:5432"

--- a/web-shared/src/api/client.ts
+++ b/web-shared/src/api/client.ts
@@ -1,7 +1,34 @@
 import axios from 'axios';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance, AxiosError } from 'axios';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '';
+
+export interface ApiErrorDetail {
+  status: number | null;
+  message: string;
+  code: string;
+}
+
+function extractErrorDetail(error: AxiosError): ApiErrorDetail {
+  if (error.code === 'ECONNABORTED') {
+    return { status: null, message: '서버 응답 시간이 초과되었습니다.', code: 'TIMEOUT' };
+  }
+  if (!error.response) {
+    return { status: null, message: '네트워크 연결을 확인해주세요.', code: 'NETWORK_ERROR' };
+  }
+  const status = error.response.status;
+  const serverMessage = (error.response.data as Record<string, unknown>)?.message;
+  if (status >= 500) {
+    return { status, message: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.', code: 'SERVER_ERROR' };
+  }
+  if (status === 404) {
+    return { status, message: '요청한 데이터를 찾을 수 없습니다.', code: 'NOT_FOUND' };
+  }
+  if (status === 400) {
+    return { status, message: (serverMessage as string) || '잘못된 요청입니다.', code: 'BAD_REQUEST' };
+  }
+  return { status, message: (serverMessage as string) || error.message, code: 'UNKNOWN' };
+}
 
 export function createApiClient(options?: {
   getApiKey?: () => string | null;
@@ -9,6 +36,7 @@ export function createApiClient(options?: {
 }): AxiosInstance {
   const client = axios.create({
     baseURL: API_BASE_URL,
+    timeout: 30000,
     headers: {
       'Content-Type': 'application/json',
     },
@@ -29,11 +57,13 @@ export function createApiClient(options?: {
 
   client.interceptors.response.use(
     (response) => response,
-    (error) => {
+    (error: AxiosError) => {
       if (error.response?.status === 401 || error.response?.status === 403) {
         options?.onUnauthorized?.();
       }
-      return Promise.reject(error);
+      const detail = extractErrorDetail(error);
+      const enriched = Object.assign(error, { apiError: detail });
+      return Promise.reject(enriched);
     },
   );
 

--- a/web-shared/src/index.ts
+++ b/web-shared/src/index.ts
@@ -6,4 +6,5 @@ export { EXAM_TYPES, SUBJECT_TYPES, QUESTION_TYPES } from './types/exam-constant
 
 // API Client
 export { createApiClient, apiClient } from './api/client.js';
+export type { ApiErrorDetail } from './api/client.js';
 export type { AxiosInstance } from 'axios';


### PR DESCRIPTION
## Summary
- #36: 미사용 MapStruct 의존성 제거 (build.gradle 경량화)
- #37: UserProfileDto 검증 패턴 - 기존 Bean Validation(@Valid, @NotBlank 등) 충분하여 추가 유틸 불요
- #38: 프론트엔드 통합 에러 핸들러 - 네트워크 에러, 타임아웃, 서버 에러별 한국어 메시지 + ApiErrorDetail 타입 export
- #39: 배포 스크립트 health check 5회 재시도 + 실패 시 자동 롤백 기능

## Test plan
- [ ] `./gradlew build` 성공 확인 (MapStruct 제거 후 빌드)
- [ ] web-shared 타입 체크 (`tsc --noEmit`)
- [ ] 배포 스크립트 dry-run 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)