### PR TITLE
feat: 합격예측(GOSI) 관리 시스템 구현

### DIFF
--- a/api/src/main/java/com/hopenvision/admin/controller/GosiExamController.java
+++ b/api/src/main/java/com/hopenvision/admin/controller/GosiExamController.java
@@ -1,0 +1,56 @@
+package com.hopenvision.admin.controller;
+
+import com.hopenvision.admin.dto.GosiExamDto;
+import com.hopenvision.admin.service.GosiExamService;
+import com.hopenvision.exam.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "합격예측 - 시험 관리", description = "시험/유형/지역 조회 API")
+@RestController
+@RequestMapping("/api/gosi/exams")
+@RequiredArgsConstructor
+@Slf4j
+public class GosiExamController {
+
+    private final GosiExamService gosiExamService;
+
+    @Operation(summary = "시험 목록 조회", description = "합격예측 시험 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<GosiExamDto.MstResponse>>> getExamList() {
+        List<GosiExamDto.MstResponse> result = gosiExamService.getExamList();
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "시험 상세 조회", description = "시험코드로 시험 상세 정보를 조회합니다.")
+    @GetMapping("/{gosiCd}")
+    public ResponseEntity<ApiResponse<GosiExamDto.MstResponse>> getExamDetail(
+            @Parameter(description = "시험코드") @PathVariable String gosiCd
+    ) {
+        GosiExamDto.MstResponse result = gosiExamService.getExamDetail(gosiCd);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "시험 유형 목록 조회", description = "합격예측 시험 유형 코드를 조회합니다.")
+    @GetMapping("/types")
+    public ResponseEntity<ApiResponse<List<GosiExamDto.CodResponse>>> getTypeList() {
+        List<GosiExamDto.CodResponse> result = gosiExamService.getTypeList();
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "지역 목록 조회", description = "시험 유형별 지역 목록을 조회합니다.")
+    @GetMapping("/areas")
+    public ResponseEntity<ApiResponse<List<GosiExamDto.AreaResponse>>> getAreaList(
+            @Parameter(description = "시험유형") @RequestParam(required = false) String gosiType
+    ) {
+        List<GosiExamDto.AreaResponse> result = gosiExamService.getAreaList(gosiType);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/controller/GosiMemberController.java
+++ b/api/src/main/java/com/hopenvision/admin/controller/GosiMemberController.java
@@ -1,0 +1,48 @@
+package com.hopenvision.admin.controller;
+
+import com.hopenvision.admin.dto.GosiMemberDto;
+import com.hopenvision.admin.service.GosiMemberService;
+import com.hopenvision.exam.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "합격예측 - 회원 관리", description = "회원 목록/상세 조회 API")
+@RestController
+@RequestMapping("/api/gosi/members")
+@RequiredArgsConstructor
+@Slf4j
+public class GosiMemberController {
+
+    private final GosiMemberService gosiMemberService;
+
+    @Operation(summary = "회원 목록 조회", description = "회원 목록을 페이징으로 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<GosiMemberDto.Response>>> getMemberList(
+            @Parameter(description = "검색어") @RequestParam(required = false) String keyword,
+            @Parameter(description = "페이지 번호") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size
+    ) {
+        GosiMemberDto.SearchRequest request = GosiMemberDto.SearchRequest.builder()
+                .keyword(keyword)
+                .page(page)
+                .size(size)
+                .build();
+        Page<GosiMemberDto.Response> result = gosiMemberService.getMemberList(request);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "회원 상세 조회", description = "회원 상세 정보를 조회합니다.")
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<GosiMemberDto.Response>> getMemberDetail(
+            @Parameter(description = "사용자ID") @PathVariable String userId
+    ) {
+        GosiMemberDto.Response result = gosiMemberService.getMemberDetail(userId);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/controller/GosiPassController.java
+++ b/api/src/main/java/com/hopenvision/admin/controller/GosiPassController.java
@@ -1,0 +1,54 @@
+package com.hopenvision.admin.controller;
+
+import com.hopenvision.admin.dto.GosiPassDto;
+import com.hopenvision.admin.service.GosiPassService;
+import com.hopenvision.exam.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "합격예측 - 정답 관리", description = "정답/합격선 조회 API")
+@RestController
+@RequestMapping("/api/gosi/pass")
+@RequiredArgsConstructor
+@Slf4j
+public class GosiPassController {
+
+    private final GosiPassService gosiPassService;
+
+    @Operation(summary = "정답 목록 조회", description = "시험 정답 목록을 페이징으로 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<GosiPassDto.PassMstResponse>>> getPassList(
+            @Parameter(description = "시험코드") @RequestParam String gosiCd,
+            @Parameter(description = "과목코드") @RequestParam(required = false) String subjectCd,
+            @Parameter(description = "시험유형") @RequestParam(required = false) String examType,
+            @Parameter(description = "페이지 번호") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size
+    ) {
+        GosiPassDto.SearchRequest request = GosiPassDto.SearchRequest.builder()
+                .gosiCd(gosiCd)
+                .subjectCd(subjectCd)
+                .examType(examType)
+                .page(page)
+                .size(size)
+                .build();
+        Page<GosiPassDto.PassMstResponse> result = gosiPassService.getPassList(request);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "합격선 조회", description = "시험 유형별 합격선을 조회합니다.")
+    @GetMapping("/standards")
+    public ResponseEntity<ApiResponse<List<GosiPassDto.PassStaResponse>>> getPassStaList(
+            @Parameter(description = "시험코드") @RequestParam String gosiCd
+    ) {
+        List<GosiPassDto.PassStaResponse> result = gosiPassService.getPassStaList(gosiCd);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/controller/GosiResultController.java
+++ b/api/src/main/java/com/hopenvision/admin/controller/GosiResultController.java
@@ -1,0 +1,55 @@
+package com.hopenvision.admin.controller;
+
+import com.hopenvision.admin.dto.GosiResultDto;
+import com.hopenvision.admin.service.GosiResultService;
+import com.hopenvision.exam.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "합격예측 - 성적 관리", description = "성적 목록/상세 조회 API")
+@RestController
+@RequestMapping("/api/gosi/results")
+@RequiredArgsConstructor
+@Slf4j
+public class GosiResultController {
+
+    private final GosiResultService gosiResultService;
+
+    @Operation(summary = "성적 목록 조회", description = "성적 목록을 페이징으로 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<GosiResultDto.RstMstResponse>>> getResultList(
+            @Parameter(description = "시험코드") @RequestParam String gosiCd,
+            @Parameter(description = "시험유형") @RequestParam(required = false) String gosiType,
+            @Parameter(description = "지역") @RequestParam(required = false) String gosiArea,
+            @Parameter(description = "검색어") @RequestParam(required = false) String keyword,
+            @Parameter(description = "페이지 번호") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size
+    ) {
+        GosiResultDto.SearchRequest request = GosiResultDto.SearchRequest.builder()
+                .gosiCd(gosiCd)
+                .gosiType(gosiType)
+                .gosiArea(gosiArea)
+                .keyword(keyword)
+                .page(page)
+                .size(size)
+                .build();
+        Page<GosiResultDto.RstMstResponse> result = gosiResultService.getResultList(request);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "성적 상세 조회", description = "성적 상세 정보를 조회합니다.")
+    @GetMapping("/{gosiCd}/{rstNo}")
+    public ResponseEntity<ApiResponse<GosiResultDto.RstDetailResponse>> getResultDetail(
+            @Parameter(description = "시험코드") @PathVariable String gosiCd,
+            @Parameter(description = "성적번호") @PathVariable String rstNo
+    ) {
+        GosiResultDto.RstDetailResponse result = gosiResultService.getResultDetail(gosiCd, rstNo);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/controller/GosiStatController.java
+++ b/api/src/main/java/com/hopenvision/admin/controller/GosiStatController.java
@@ -1,0 +1,61 @@
+package com.hopenvision.admin.controller;
+
+import com.hopenvision.admin.dto.GosiStatDto;
+import com.hopenvision.admin.service.GosiStatService;
+import com.hopenvision.exam.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "합격예측 - 통계", description = "통계 조회/대시보드 API")
+@RestController
+@RequestMapping("/api/gosi/statistics")
+@RequiredArgsConstructor
+@Slf4j
+public class GosiStatController {
+
+    private final GosiStatService gosiStatService;
+
+    @Operation(summary = "통계 목록 조회", description = "통계 목록을 페이징으로 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<GosiStatDto.StatMstResponse>>> getStatList(
+            @Parameter(description = "시험코드") @RequestParam String gosiCd,
+            @Parameter(description = "시험유형") @RequestParam(required = false) String gosiType,
+            @Parameter(description = "페이지 번호") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size
+    ) {
+        GosiStatDto.SearchRequest request = GosiStatDto.SearchRequest.builder()
+                .gosiCd(gosiCd)
+                .gosiType(gosiType)
+                .page(page)
+                .size(size)
+                .build();
+        Page<GosiStatDto.StatMstResponse> result = gosiStatService.getStatList(request);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "대시보드 조회", description = "시험 전체 통계를 조회합니다.")
+    @GetMapping("/dashboard")
+    public ResponseEntity<ApiResponse<List<GosiStatDto.StatMstResponse>>> getDashboard(
+            @Parameter(description = "시험코드") @RequestParam String gosiCd
+    ) {
+        List<GosiStatDto.StatMstResponse> result = gosiStatService.getDashboard(gosiCd);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "과목 구분 목록 조회", description = "시험별 과목 구분 목록을 조회합니다.")
+    @GetMapping("/subjects")
+    public ResponseEntity<ApiResponse<List<GosiStatDto.SbjMstResponse>>> getSbjMstList(
+            @Parameter(description = "시험코드") @RequestParam String gosiCd
+    ) {
+        List<GosiStatDto.SbjMstResponse> result = gosiStatService.getSbjMstList(gosiCd);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/controller/GosiSubjectController.java
+++ b/api/src/main/java/com/hopenvision/admin/controller/GosiSubjectController.java
@@ -1,0 +1,53 @@
+package com.hopenvision.admin.controller;
+
+import com.hopenvision.admin.dto.GosiSubjectDto;
+import com.hopenvision.admin.dto.GosiVodDto;
+import com.hopenvision.admin.service.GosiSubjectService;
+import com.hopenvision.exam.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "합격예측 - 과목/VOD", description = "과목/VOD 조회 API")
+@RestController
+@RequestMapping("/api/gosi/subjects")
+@RequiredArgsConstructor
+@Slf4j
+public class GosiSubjectController {
+
+    private final GosiSubjectService gosiSubjectService;
+
+    @Operation(summary = "과목 목록 조회", description = "시험 유형별 과목 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<GosiSubjectDto.Response>>> getSubjectList(
+            @Parameter(description = "시험유형") @RequestParam(required = false) String gosiType
+    ) {
+        List<GosiSubjectDto.Response> result = gosiSubjectService.getSubjectList(gosiType);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "VOD 목록 조회", description = "VOD 목록을 페이징으로 조회합니다.")
+    @GetMapping("/vods")
+    public ResponseEntity<ApiResponse<Page<GosiVodDto.Response>>> getVodList(
+            @Parameter(description = "시험코드") @RequestParam(required = false) String gosiCd,
+            @Parameter(description = "검색어") @RequestParam(required = false) String keyword,
+            @Parameter(description = "페이지 번호") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size
+    ) {
+        GosiVodDto.SearchRequest request = GosiVodDto.SearchRequest.builder()
+                .gosiCd(gosiCd)
+                .keyword(keyword)
+                .page(page)
+                .size(size)
+                .build();
+        Page<GosiVodDto.Response> result = gosiSubjectService.getVodList(request);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/dto/GosiExamDto.java
+++ b/api/src/main/java/com/hopenvision/admin/dto/GosiExamDto.java
@@ -1,0 +1,63 @@
+package com.hopenvision.admin.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class GosiExamDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MstResponse {
+        private String gosiCd;
+        private String gosiNm;
+        private String gosiType;
+        private LocalDateTime startDt;
+        private LocalDateTime endDt;
+        private String isuse;
+        private LocalDateTime regDt;
+        private String gosiYear;
+        private String gosiRound;
+        private BigDecimal totalScore;
+        private BigDecimal passScore;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CodResponse {
+        private String gosiType;
+        private String gosiTypeNm;
+        private String isuse;
+        private String pos;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AreaResponse {
+        private String gosiType;
+        private String gosiArea;
+        private String gosiAreaNm;
+        private String isuse;
+        private String pos;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AreaSearchRequest {
+        private String gosiType;
+        private String isuse;
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/dto/GosiMemberDto.java
+++ b/api/src/main/java/com/hopenvision/admin/dto/GosiMemberDto.java
@@ -1,0 +1,39 @@
+package com.hopenvision.admin.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class GosiMemberDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String userId;
+        private String userNm;
+        private String userNicknm;
+        private String userPosition;
+        private String sex;
+        private String userRole;
+        private String adminRole;
+        private LocalDateTime birthDay;
+        private String categoryCode;
+        private Integer userPoint;
+        private Integer payment;
+        private String isuse;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SearchRequest {
+        private String keyword;
+        private int page = 0;
+        private int size = 20;
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/dto/GosiPassDto.java
+++ b/api/src/main/java/com/hopenvision/admin/dto/GosiPassDto.java
@@ -1,0 +1,48 @@
+package com.hopenvision.admin.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+public class GosiPassDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PassMstResponse {
+        private String gosiCd;
+        private String subjectCd;
+        private String examType;
+        private Integer itemNo;
+        private String answerData;
+        private String subjectNm;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PassStaResponse {
+        private String gosiCd;
+        private String gosiType;
+        private String gosiTypeNm;
+        private BigDecimal passScore;
+        private String isuse;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SearchRequest {
+        private String gosiCd;
+        private String subjectCd;
+        private String examType;
+        private int page = 0;
+        private int size = 20;
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/dto/GosiResultDto.java
+++ b/api/src/main/java/com/hopenvision/admin/dto/GosiResultDto.java
@@ -1,0 +1,83 @@
+package com.hopenvision.admin.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class GosiResultDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RstMstResponse {
+        private String gosiCd;
+        private String rstNo;
+        private String userId;
+        private String gosiType;
+        private String gosiArea;
+        private BigDecimal totalScore;
+        private BigDecimal avgScore;
+        private String passYn;
+        private LocalDateTime regDt;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RstDetResponse {
+        private String gosiCd;
+        private String rstNo;
+        private String subjectCd;
+        private Integer itemNo;
+        private String userId;
+        private String answerData;
+        private String isCorrect;
+        private LocalDateTime regDt;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RstSbjResponse {
+        private String gosiCd;
+        private String rstNo;
+        private String subjectCd;
+        private String subjectNm;
+        private BigDecimal score;
+        private Integer correctCnt;
+        private Integer totalCnt;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RstDetailResponse {
+        private RstMstResponse master;
+        private List<RstSbjResponse> subjects;
+        private List<RstDetResponse> details;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SearchRequest {
+        private String gosiCd;
+        private String gosiType;
+        private String gosiArea;
+        private String keyword;
+        private int page = 0;
+        private int size = 20;
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/dto/GosiStatDto.java
+++ b/api/src/main/java/com/hopenvision/admin/dto/GosiStatDto.java
@@ -1,0 +1,55 @@
+package com.hopenvision.admin.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+public class GosiStatDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class StatMstResponse {
+        private String gosiCd;
+        private String gosiType;
+        private String gosiArea;
+        private String gosiSubjectCd;
+        private String gosiTypeNm;
+        private String gosiAreaNm;
+        private String gosiSubjectNm;
+        private Integer totalCnt;
+        private BigDecimal avgScore;
+        private BigDecimal maxScore;
+        private BigDecimal minScore;
+        private Integer passCnt;
+        private BigDecimal passRate;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SbjMstResponse {
+        private String gosiCd;
+        private String sbjType;
+        private String subjectCd;
+        private String subjectNm;
+        private String isuse;
+        private String pos;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SearchRequest {
+        private String gosiCd;
+        private String gosiType;
+        private int page = 0;
+        private int size = 20;
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/dto/GosiSubjectDto.java
+++ b/api/src/main/java/com/hopenvision/admin/dto/GosiSubjectDto.java
@@ -1,0 +1,29 @@
+package com.hopenvision.admin.dto;
+
+import lombok.*;
+
+public class GosiSubjectDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String gosiType;
+        private String gosiSubjectCd;
+        private String gosiSubjecNm;
+        private String isuse;
+        private String pos;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SearchRequest {
+        private String gosiType;
+        private String isuse;
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/dto/GosiVodDto.java
+++ b/api/src/main/java/com/hopenvision/admin/dto/GosiVodDto.java
@@ -1,0 +1,35 @@
+package com.hopenvision.admin.dto;
+
+import lombok.*;
+
+public class GosiVodDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+        private String gosiCd;
+        private String prfId;
+        private Integer idx;
+        private String subjectCd;
+        private String subjectNm;
+        private String prfNm;
+        private String vodUrl;
+        private String vodNm;
+        private String isuse;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SearchRequest {
+        private String gosiCd;
+        private String keyword;
+        private int page = 0;
+        private int size = 20;
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiAreaMst.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiAreaMst.java
@@ -1,0 +1,32 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gosi_area_mst")
+@IdClass(GosiAreaMstId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiAreaMst {
+
+    @Id
+    @Column(name = "gosi_type", length = 50)
+    private String gosiType;
+
+    @Id
+    @Column(name = "gosi_area", length = 50)
+    private String gosiArea;
+
+    @Column(name = "gosi_area_nm", length = 200)
+    private String gosiAreaNm;
+
+    @Column(name = "isuse", length = 10)
+    private String isuse;
+
+    @Column(name = "pos", length = 10)
+    private String pos;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiAreaMstId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiAreaMstId.java
@@ -1,0 +1,15 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiAreaMstId implements Serializable {
+    private String gosiType;
+    private String gosiArea;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiCod.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiCod.java
@@ -1,0 +1,27 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gosi_cod")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiCod {
+
+    @Id
+    @Column(name = "gosi_type", length = 50)
+    private String gosiType;
+
+    @Column(name = "gosi_type_nm", length = 200)
+    private String gosiTypeNm;
+
+    @Column(name = "isuse", length = 10)
+    private String isuse;
+
+    @Column(name = "pos", length = 10)
+    private String pos;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiMember.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiMember.java
@@ -1,0 +1,68 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_ma_member")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiMember {
+
+    @Id
+    @Column(name = "user_id", length = 100)
+    private String userId;
+
+    @Column(name = "user_nm", length = 200)
+    private String userNm;
+
+    @Column(name = "user_nicknm", length = 200)
+    private String userNicknm;
+
+    @Column(name = "user_position", length = 100)
+    private String userPosition;
+
+    @Column(name = "sex", length = 10)
+    private String sex;
+
+    @Column(name = "user_role", length = 50)
+    private String userRole;
+
+    @Column(name = "admin_role", length = 50)
+    private String adminRole;
+
+    @Column(name = "user_pwd", length = 500)
+    private String userPwd;
+
+    @Column(name = "birth_day")
+    private LocalDateTime birthDay;
+
+    @Column(name = "category_code", length = 100)
+    private String categoryCode;
+
+    @Column(name = "user_point")
+    private Integer userPoint;
+
+    @Column(name = "payment")
+    private Integer payment;
+
+    @Column(name = "pic1", length = 500)
+    private String pic1;
+
+    @Column(name = "pic2", length = 500)
+    private String pic2;
+
+    @Column(name = "pic3", length = 500)
+    private String pic3;
+
+    @Column(name = "pic4", length = 500)
+    private String pic4;
+
+    @Column(name = "isuse", length = 10)
+    private String isuse;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiMst.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiMst.java
@@ -1,0 +1,54 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "gosi_mst")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiMst {
+
+    @Id
+    @Column(name = "gosi_cd", length = 50)
+    private String gosiCd;
+
+    @Column(name = "gosi_nm", length = 200)
+    private String gosiNm;
+
+    @Column(name = "gosi_type", length = 50)
+    private String gosiType;
+
+    @Column(name = "start_dt")
+    private LocalDateTime startDt;
+
+    @Column(name = "end_dt")
+    private LocalDateTime endDt;
+
+    @Column(name = "isuse", length = 10)
+    private String isuse;
+
+    @Column(name = "reg_dt")
+    private LocalDateTime regDt;
+
+    @Column(name = "reg_ip", length = 50)
+    private String regIp;
+
+    @Column(name = "gosi_year", length = 10)
+    private String gosiYear;
+
+    @Column(name = "gosi_round", length = 10)
+    private String gosiRound;
+
+    @Column(name = "total_score", precision = 10, scale = 2)
+    private BigDecimal totalScore;
+
+    @Column(name = "pass_score", precision = 10, scale = 2)
+    private BigDecimal passScore;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiPassMst.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiPassMst.java
@@ -1,0 +1,37 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gosi_pass_mst")
+@IdClass(GosiPassMstId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiPassMst {
+
+    @Id
+    @Column(name = "gosi_cd", length = 50)
+    private String gosiCd;
+
+    @Id
+    @Column(name = "subject_cd", length = 50)
+    private String subjectCd;
+
+    @Id
+    @Column(name = "exam_type", length = 50)
+    private String examType;
+
+    @Id
+    @Column(name = "item_no")
+    private Integer itemNo;
+
+    @Column(name = "answer_data", length = 10)
+    private String answerData;
+
+    @Column(name = "subject_nm", length = 200)
+    private String subjectNm;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiPassMstId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiPassMstId.java
@@ -1,0 +1,17 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiPassMstId implements Serializable {
+    private String gosiCd;
+    private String subjectCd;
+    private String examType;
+    private Integer itemNo;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiPassSta.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiPassSta.java
@@ -1,0 +1,34 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "gosi_pass_sta")
+@IdClass(GosiPassStaId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiPassSta {
+
+    @Id
+    @Column(name = "gosi_cd", length = 50)
+    private String gosiCd;
+
+    @Id
+    @Column(name = "gosi_type", length = 50)
+    private String gosiType;
+
+    @Column(name = "gosi_type_nm", length = 200)
+    private String gosiTypeNm;
+
+    @Column(name = "pass_score", precision = 10, scale = 2)
+    private BigDecimal passScore;
+
+    @Column(name = "isuse", length = 10)
+    private String isuse;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiPassStaId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiPassStaId.java
@@ -1,0 +1,15 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiPassStaId implements Serializable {
+    private String gosiCd;
+    private String gosiType;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiRstDet.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiRstDet.java
@@ -1,0 +1,45 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "gosi_rst_det")
+@IdClass(GosiRstDetId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiRstDet {
+
+    @Id
+    @Column(name = "gosi_cd", length = 50)
+    private String gosiCd;
+
+    @Id
+    @Column(name = "rst_no", length = 50)
+    private String rstNo;
+
+    @Id
+    @Column(name = "subject_cd", length = 50)
+    private String subjectCd;
+
+    @Id
+    @Column(name = "item_no")
+    private Integer itemNo;
+
+    @Column(name = "user_id", length = 100)
+    private String userId;
+
+    @Column(name = "answer_data", length = 10)
+    private String answerData;
+
+    @Column(name = "is_correct", length = 10)
+    private String isCorrect;
+
+    @Column(name = "reg_dt")
+    private LocalDateTime regDt;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiRstDetId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiRstDetId.java
@@ -1,0 +1,17 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiRstDetId implements Serializable {
+    private String gosiCd;
+    private String rstNo;
+    private String subjectCd;
+    private Integer itemNo;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiRstMst.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiRstMst.java
@@ -1,0 +1,47 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "gosi_rst_mst")
+@IdClass(GosiRstMstId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiRstMst {
+
+    @Id
+    @Column(name = "gosi_cd", length = 50)
+    private String gosiCd;
+
+    @Id
+    @Column(name = "rst_no", length = 50)
+    private String rstNo;
+
+    @Column(name = "user_id", length = 100)
+    private String userId;
+
+    @Column(name = "gosi_type", length = 50)
+    private String gosiType;
+
+    @Column(name = "gosi_area", length = 50)
+    private String gosiArea;
+
+    @Column(name = "total_score", precision = 10, scale = 2)
+    private BigDecimal totalScore;
+
+    @Column(name = "avg_score", precision = 10, scale = 2)
+    private BigDecimal avgScore;
+
+    @Column(name = "pass_yn", length = 10)
+    private String passYn;
+
+    @Column(name = "reg_dt")
+    private LocalDateTime regDt;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiRstMstId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiRstMstId.java
@@ -1,0 +1,15 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiRstMstId implements Serializable {
+    private String gosiCd;
+    private String rstNo;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiRstSbj.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiRstSbj.java
@@ -1,0 +1,41 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "gosi_rst_sbj")
+@IdClass(GosiRstSbjId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiRstSbj {
+
+    @Id
+    @Column(name = "gosi_cd", length = 50)
+    private String gosiCd;
+
+    @Id
+    @Column(name = "rst_no", length = 50)
+    private String rstNo;
+
+    @Id
+    @Column(name = "subject_cd", length = 50)
+    private String subjectCd;
+
+    @Column(name = "subject_nm", length = 200)
+    private String subjectNm;
+
+    @Column(name = "score", precision = 10, scale = 2)
+    private BigDecimal score;
+
+    @Column(name = "correct_cnt")
+    private Integer correctCnt;
+
+    @Column(name = "total_cnt")
+    private Integer totalCnt;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiRstSbjId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiRstSbjId.java
@@ -1,0 +1,16 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiRstSbjId implements Serializable {
+    private String gosiCd;
+    private String rstNo;
+    private String subjectCd;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiSbjMst.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiSbjMst.java
@@ -1,0 +1,36 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gosi_sbj_mst")
+@IdClass(GosiSbjMstId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiSbjMst {
+
+    @Id
+    @Column(name = "gosi_cd", length = 50)
+    private String gosiCd;
+
+    @Id
+    @Column(name = "sbj_type", length = 50)
+    private String sbjType;
+
+    @Id
+    @Column(name = "subject_cd", length = 50)
+    private String subjectCd;
+
+    @Column(name = "subject_nm", length = 200)
+    private String subjectNm;
+
+    @Column(name = "isuse", length = 10)
+    private String isuse;
+
+    @Column(name = "pos", length = 10)
+    private String pos;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiSbjMstId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiSbjMstId.java
@@ -1,0 +1,16 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiSbjMstId implements Serializable {
+    private String gosiCd;
+    private String sbjType;
+    private String subjectCd;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiStatMst.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiStatMst.java
@@ -1,0 +1,60 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "gosi_stat_mst")
+@IdClass(GosiStatMstId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiStatMst {
+
+    @Id
+    @Column(name = "gosi_cd", length = 50)
+    private String gosiCd;
+
+    @Id
+    @Column(name = "gosi_type", length = 50)
+    private String gosiType;
+
+    @Id
+    @Column(name = "gosi_area", length = 50)
+    private String gosiArea;
+
+    @Id
+    @Column(name = "gosi_subject_cd", length = 50)
+    private String gosiSubjectCd;
+
+    @Column(name = "gosi_type_nm", length = 200)
+    private String gosiTypeNm;
+
+    @Column(name = "gosi_area_nm", length = 200)
+    private String gosiAreaNm;
+
+    @Column(name = "gosi_subject_nm", length = 200)
+    private String gosiSubjectNm;
+
+    @Column(name = "total_cnt")
+    private Integer totalCnt;
+
+    @Column(name = "avg_score", precision = 10, scale = 2)
+    private BigDecimal avgScore;
+
+    @Column(name = "max_score", precision = 10, scale = 2)
+    private BigDecimal maxScore;
+
+    @Column(name = "min_score", precision = 10, scale = 2)
+    private BigDecimal minScore;
+
+    @Column(name = "pass_cnt")
+    private Integer passCnt;
+
+    @Column(name = "pass_rate", precision = 10, scale = 2)
+    private BigDecimal passRate;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiStatMstId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiStatMstId.java
@@ -1,0 +1,17 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiStatMstId implements Serializable {
+    private String gosiCd;
+    private String gosiType;
+    private String gosiArea;
+    private String gosiSubjectCd;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiSubject.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiSubject.java
@@ -1,0 +1,32 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gosi_subject")
+@IdClass(GosiSubjectId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiSubject {
+
+    @Id
+    @Column(name = "gosi_type", length = 50)
+    private String gosiType;
+
+    @Id
+    @Column(name = "gosi_subject_cd", length = 50)
+    private String gosiSubjectCd;
+
+    @Column(name = "gosi_subjec_nm", length = 200)
+    private String gosiSubjecNm;
+
+    @Column(name = "isuse", length = 10)
+    private String isuse;
+
+    @Column(name = "pos", length = 10)
+    private String pos;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiSubjectId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiSubjectId.java
@@ -1,0 +1,15 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiSubjectId implements Serializable {
+    private String gosiType;
+    private String gosiSubjectCd;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiVod.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiVod.java
@@ -1,0 +1,45 @@
+package com.hopenvision.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gosi_vod")
+@IdClass(GosiVodId.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GosiVod {
+
+    @Id
+    @Column(name = "gosi_cd", length = 50)
+    private String gosiCd;
+
+    @Id
+    @Column(name = "prf_id", length = 100)
+    private String prfId;
+
+    @Id
+    @Column(name = "idx")
+    private Integer idx;
+
+    @Column(name = "subject_cd", length = 50)
+    private String subjectCd;
+
+    @Column(name = "subject_nm", length = 200)
+    private String subjectNm;
+
+    @Column(name = "prf_nm", length = 200)
+    private String prfNm;
+
+    @Column(name = "vod_url", length = 1000)
+    private String vodUrl;
+
+    @Column(name = "vod_nm", length = 500)
+    private String vodNm;
+
+    @Column(name = "isuse", length = 10)
+    private String isuse;
+}

--- a/api/src/main/java/com/hopenvision/admin/entity/GosiVodId.java
+++ b/api/src/main/java/com/hopenvision/admin/entity/GosiVodId.java
@@ -1,0 +1,16 @@
+package com.hopenvision.admin.entity;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GosiVodId implements Serializable {
+    private String gosiCd;
+    private String prfId;
+    private Integer idx;
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiAreaMstRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiAreaMstRepository.java
@@ -1,0 +1,16 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiAreaMst;
+import com.hopenvision.admin.entity.GosiAreaMstId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GosiAreaMstRepository extends JpaRepository<GosiAreaMst, GosiAreaMstId> {
+
+    List<GosiAreaMst> findByGosiTypeOrderByPos(String gosiType);
+
+    List<GosiAreaMst> findByGosiTypeAndIsuseOrderByPos(String gosiType, String isuse);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiCodRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiCodRepository.java
@@ -1,0 +1,13 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiCod;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GosiCodRepository extends JpaRepository<GosiCod, String> {
+
+    List<GosiCod> findByIsuseOrderByPos(String isuse);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiMemberRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiMemberRepository.java
@@ -1,0 +1,20 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiMember;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GosiMemberRepository extends JpaRepository<GosiMember, String> {
+
+    @Query("SELECT m FROM GosiMember m WHERE " +
+           "(:keyword IS NULL OR :keyword = '' OR m.userId LIKE %:keyword% OR m.userNm LIKE %:keyword% OR m.userNicknm LIKE %:keyword%) " +
+           "ORDER BY m.userId")
+    Page<GosiMember> search(
+            @Param("keyword") String keyword,
+            Pageable pageable);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiMstRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiMstRepository.java
@@ -1,0 +1,9 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiMst;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GosiMstRepository extends JpaRepository<GosiMst, String> {
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiPassMstRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiPassMstRepository.java
@@ -1,0 +1,30 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiPassMst;
+import com.hopenvision.admin.entity.GosiPassMstId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GosiPassMstRepository extends JpaRepository<GosiPassMst, GosiPassMstId> {
+
+    List<GosiPassMst> findByGosiCdOrderBySubjectCdAscItemNoAsc(String gosiCd);
+
+    List<GosiPassMst> findByGosiCdAndSubjectCdOrderByItemNo(String gosiCd, String subjectCd);
+
+    @Query("SELECT p FROM GosiPassMst p WHERE p.gosiCd = :gosiCd " +
+           "AND (:subjectCd IS NULL OR :subjectCd = '' OR p.subjectCd = :subjectCd) " +
+           "AND (:examType IS NULL OR :examType = '' OR p.examType = :examType) " +
+           "ORDER BY p.subjectCd, p.itemNo")
+    Page<GosiPassMst> search(
+            @Param("gosiCd") String gosiCd,
+            @Param("subjectCd") String subjectCd,
+            @Param("examType") String examType,
+            Pageable pageable);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiPassStaRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiPassStaRepository.java
@@ -1,0 +1,14 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiPassSta;
+import com.hopenvision.admin.entity.GosiPassStaId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GosiPassStaRepository extends JpaRepository<GosiPassSta, GosiPassStaId> {
+
+    List<GosiPassSta> findByGosiCd(String gosiCd);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiRstDetRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiRstDetRepository.java
@@ -1,0 +1,14 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiRstDet;
+import com.hopenvision.admin.entity.GosiRstDetId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GosiRstDetRepository extends JpaRepository<GosiRstDet, GosiRstDetId> {
+
+    List<GosiRstDet> findByGosiCdAndRstNoOrderBySubjectCdAscItemNoAsc(String gosiCd, String rstNo);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiRstMstRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiRstMstRepository.java
@@ -1,0 +1,26 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiRstMst;
+import com.hopenvision.admin.entity.GosiRstMstId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GosiRstMstRepository extends JpaRepository<GosiRstMst, GosiRstMstId> {
+
+    @Query("SELECT r FROM GosiRstMst r WHERE r.gosiCd = :gosiCd " +
+           "AND (:gosiType IS NULL OR :gosiType = '' OR r.gosiType = :gosiType) " +
+           "AND (:gosiArea IS NULL OR :gosiArea = '' OR r.gosiArea = :gosiArea) " +
+           "AND (:keyword IS NULL OR :keyword = '' OR r.userId LIKE %:keyword% OR r.rstNo LIKE %:keyword%) " +
+           "ORDER BY r.regDt DESC")
+    Page<GosiRstMst> search(
+            @Param("gosiCd") String gosiCd,
+            @Param("gosiType") String gosiType,
+            @Param("gosiArea") String gosiArea,
+            @Param("keyword") String keyword,
+            Pageable pageable);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiRstSbjRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiRstSbjRepository.java
@@ -1,0 +1,14 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiRstSbj;
+import com.hopenvision.admin.entity.GosiRstSbjId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GosiRstSbjRepository extends JpaRepository<GosiRstSbj, GosiRstSbjId> {
+
+    List<GosiRstSbj> findByGosiCdAndRstNoOrderBySubjectCd(String gosiCd, String rstNo);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiSbjMstRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiSbjMstRepository.java
@@ -1,0 +1,14 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiSbjMst;
+import com.hopenvision.admin.entity.GosiSbjMstId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GosiSbjMstRepository extends JpaRepository<GosiSbjMst, GosiSbjMstId> {
+
+    List<GosiSbjMst> findByGosiCdOrderBySbjTypeAscSubjectCdAsc(String gosiCd);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiStatMstRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiStatMstRepository.java
@@ -1,0 +1,26 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiStatMst;
+import com.hopenvision.admin.entity.GosiStatMstId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GosiStatMstRepository extends JpaRepository<GosiStatMst, GosiStatMstId> {
+
+    @Query("SELECT s FROM GosiStatMst s WHERE s.gosiCd = :gosiCd " +
+           "AND (:gosiType IS NULL OR :gosiType = '' OR s.gosiType = :gosiType) " +
+           "ORDER BY s.gosiType, s.gosiArea, s.gosiSubjectCd")
+    Page<GosiStatMst> search(
+            @Param("gosiCd") String gosiCd,
+            @Param("gosiType") String gosiType,
+            Pageable pageable);
+
+    List<GosiStatMst> findByGosiCdOrderByGosiTypeAscGosiAreaAsc(String gosiCd);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiSubjectRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiSubjectRepository.java
@@ -1,0 +1,16 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiSubject;
+import com.hopenvision.admin.entity.GosiSubjectId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface GosiSubjectRepository extends JpaRepository<GosiSubject, GosiSubjectId> {
+
+    List<GosiSubject> findByGosiTypeOrderByPos(String gosiType);
+
+    List<GosiSubject> findByGosiTypeAndIsuseOrderByPos(String gosiType, String isuse);
+}

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiVodRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiVodRepository.java
@@ -1,0 +1,23 @@
+package com.hopenvision.admin.repository;
+
+import com.hopenvision.admin.entity.GosiVod;
+import com.hopenvision.admin.entity.GosiVodId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GosiVodRepository extends JpaRepository<GosiVod, GosiVodId> {
+
+    @Query("SELECT v FROM GosiVod v WHERE " +
+           "(:gosiCd IS NULL OR :gosiCd = '' OR v.gosiCd = :gosiCd) " +
+           "AND (:keyword IS NULL OR :keyword = '' OR v.subjectNm LIKE %:keyword% OR v.prfNm LIKE %:keyword% OR v.vodNm LIKE %:keyword%) " +
+           "ORDER BY v.gosiCd, v.subjectCd, v.idx")
+    Page<GosiVod> search(
+            @Param("gosiCd") String gosiCd,
+            @Param("keyword") String keyword,
+            Pageable pageable);
+}

--- a/api/src/main/java/com/hopenvision/admin/service/GosiExamService.java
+++ b/api/src/main/java/com/hopenvision/admin/service/GosiExamService.java
@@ -1,0 +1,104 @@
+package com.hopenvision.admin.service;
+
+import com.hopenvision.admin.dto.GosiExamDto;
+import com.hopenvision.admin.entity.GosiAreaMst;
+import com.hopenvision.admin.entity.GosiCod;
+import com.hopenvision.admin.entity.GosiMst;
+import com.hopenvision.admin.repository.GosiAreaMstRepository;
+import com.hopenvision.admin.repository.GosiCodRepository;
+import com.hopenvision.admin.repository.GosiMstRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class GosiExamService {
+
+    private final GosiMstRepository gosiMstRepository;
+    private final GosiCodRepository gosiCodRepository;
+    private final GosiAreaMstRepository gosiAreaMstRepository;
+
+    /**
+     * 시험 목록 조회
+     */
+    public List<GosiExamDto.MstResponse> getExamList() {
+        return gosiMstRepository.findAll().stream()
+                .map(this::toMstResponse)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 시험 상세 조회
+     */
+    public GosiExamDto.MstResponse getExamDetail(String gosiCd) {
+        GosiMst mst = gosiMstRepository.findById(gosiCd)
+                .orElseThrow(() -> new jakarta.persistence.EntityNotFoundException("시험을 찾을 수 없습니다: " + gosiCd));
+        return toMstResponse(mst);
+    }
+
+    /**
+     * 시험 유형 목록 조회
+     */
+    public List<GosiExamDto.CodResponse> getTypeList() {
+        return gosiCodRepository.findAll().stream()
+                .map(this::toCodResponse)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 지역 목록 조회
+     */
+    public List<GosiExamDto.AreaResponse> getAreaList(String gosiType) {
+        List<GosiAreaMst> areas;
+        if (gosiType != null && !gosiType.isEmpty()) {
+            areas = gosiAreaMstRepository.findByGosiTypeOrderByPos(gosiType);
+        } else {
+            areas = gosiAreaMstRepository.findAll();
+        }
+        return areas.stream()
+                .map(this::toAreaResponse)
+                .collect(Collectors.toList());
+    }
+
+    private GosiExamDto.MstResponse toMstResponse(GosiMst entity) {
+        return GosiExamDto.MstResponse.builder()
+                .gosiCd(entity.getGosiCd())
+                .gosiNm(entity.getGosiNm())
+                .gosiType(entity.getGosiType())
+                .startDt(entity.getStartDt())
+                .endDt(entity.getEndDt())
+                .isuse(entity.getIsuse())
+                .regDt(entity.getRegDt())
+                .gosiYear(entity.getGosiYear())
+                .gosiRound(entity.getGosiRound())
+                .totalScore(entity.getTotalScore())
+                .passScore(entity.getPassScore())
+                .build();
+    }
+
+    private GosiExamDto.CodResponse toCodResponse(GosiCod entity) {
+        return GosiExamDto.CodResponse.builder()
+                .gosiType(entity.getGosiType())
+                .gosiTypeNm(entity.getGosiTypeNm())
+                .isuse(entity.getIsuse())
+                .pos(entity.getPos())
+                .build();
+    }
+
+    private GosiExamDto.AreaResponse toAreaResponse(GosiAreaMst entity) {
+        return GosiExamDto.AreaResponse.builder()
+                .gosiType(entity.getGosiType())
+                .gosiArea(entity.getGosiArea())
+                .gosiAreaNm(entity.getGosiAreaNm())
+                .isuse(entity.getIsuse())
+                .pos(entity.getPos())
+                .build();
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/service/GosiMemberService.java
+++ b/api/src/main/java/com/hopenvision/admin/service/GosiMemberService.java
@@ -1,0 +1,57 @@
+package com.hopenvision.admin.service;
+
+import com.hopenvision.admin.dto.GosiMemberDto;
+import com.hopenvision.admin.entity.GosiMember;
+import com.hopenvision.admin.repository.GosiMemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class GosiMemberService {
+
+    private final GosiMemberRepository gosiMemberRepository;
+
+    /**
+     * 회원 목록 조회 (페이징)
+     */
+    public Page<GosiMemberDto.Response> getMemberList(GosiMemberDto.SearchRequest request) {
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+        return gosiMemberRepository.search(request.getKeyword(), pageable)
+                .map(this::toResponse);
+    }
+
+    /**
+     * 회원 상세 조회
+     */
+    public GosiMemberDto.Response getMemberDetail(String userId) {
+        GosiMember member = gosiMemberRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("회원을 찾을 수 없습니다: " + userId));
+        return toResponse(member);
+    }
+
+    private GosiMemberDto.Response toResponse(GosiMember entity) {
+        return GosiMemberDto.Response.builder()
+                .userId(entity.getUserId())
+                .userNm(entity.getUserNm())
+                .userNicknm(entity.getUserNicknm())
+                .userPosition(entity.getUserPosition())
+                .sex(entity.getSex())
+                .userRole(entity.getUserRole())
+                .adminRole(entity.getAdminRole())
+                .birthDay(entity.getBirthDay())
+                .categoryCode(entity.getCategoryCode())
+                .userPoint(entity.getUserPoint())
+                .payment(entity.getPayment())
+                .isuse(entity.getIsuse())
+                .build();
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/service/GosiPassService.java
+++ b/api/src/main/java/com/hopenvision/admin/service/GosiPassService.java
@@ -1,0 +1,70 @@
+package com.hopenvision.admin.service;
+
+import com.hopenvision.admin.dto.GosiPassDto;
+import com.hopenvision.admin.entity.GosiPassMst;
+import com.hopenvision.admin.entity.GosiPassSta;
+import com.hopenvision.admin.repository.GosiPassMstRepository;
+import com.hopenvision.admin.repository.GosiPassStaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class GosiPassService {
+
+    private final GosiPassMstRepository gosiPassMstRepository;
+    private final GosiPassStaRepository gosiPassStaRepository;
+
+    /**
+     * 정답 목록 조회 (페이징)
+     */
+    public Page<GosiPassDto.PassMstResponse> getPassList(GosiPassDto.SearchRequest request) {
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+        return gosiPassMstRepository.search(
+                request.getGosiCd(),
+                request.getSubjectCd(),
+                request.getExamType(),
+                pageable
+        ).map(this::toPassMstResponse);
+    }
+
+    /**
+     * 합격선 조회
+     */
+    public List<GosiPassDto.PassStaResponse> getPassStaList(String gosiCd) {
+        return gosiPassStaRepository.findByGosiCd(gosiCd).stream()
+                .map(this::toPassStaResponse)
+                .collect(Collectors.toList());
+    }
+
+    private GosiPassDto.PassMstResponse toPassMstResponse(GosiPassMst entity) {
+        return GosiPassDto.PassMstResponse.builder()
+                .gosiCd(entity.getGosiCd())
+                .subjectCd(entity.getSubjectCd())
+                .examType(entity.getExamType())
+                .itemNo(entity.getItemNo())
+                .answerData(entity.getAnswerData())
+                .subjectNm(entity.getSubjectNm())
+                .build();
+    }
+
+    private GosiPassDto.PassStaResponse toPassStaResponse(GosiPassSta entity) {
+        return GosiPassDto.PassStaResponse.builder()
+                .gosiCd(entity.getGosiCd())
+                .gosiType(entity.getGosiType())
+                .gosiTypeNm(entity.getGosiTypeNm())
+                .passScore(entity.getPassScore())
+                .isuse(entity.getIsuse())
+                .build();
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/service/GosiResultService.java
+++ b/api/src/main/java/com/hopenvision/admin/service/GosiResultService.java
@@ -1,0 +1,102 @@
+package com.hopenvision.admin.service;
+
+import com.hopenvision.admin.dto.GosiResultDto;
+import com.hopenvision.admin.entity.GosiRstDet;
+import com.hopenvision.admin.entity.GosiRstMst;
+import com.hopenvision.admin.entity.GosiRstMstId;
+import com.hopenvision.admin.entity.GosiRstSbj;
+import com.hopenvision.admin.repository.GosiRstDetRepository;
+import com.hopenvision.admin.repository.GosiRstMstRepository;
+import com.hopenvision.admin.repository.GosiRstSbjRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class GosiResultService {
+
+    private final GosiRstMstRepository gosiRstMstRepository;
+    private final GosiRstDetRepository gosiRstDetRepository;
+    private final GosiRstSbjRepository gosiRstSbjRepository;
+
+    /**
+     * 성적 목록 조회 (페이징)
+     */
+    public Page<GosiResultDto.RstMstResponse> getResultList(GosiResultDto.SearchRequest request) {
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+        return gosiRstMstRepository.search(
+                request.getGosiCd(),
+                request.getGosiType(),
+                request.getGosiArea(),
+                request.getKeyword(),
+                pageable
+        ).map(this::toRstMstResponse);
+    }
+
+    /**
+     * 성적 상세 조회
+     */
+    public GosiResultDto.RstDetailResponse getResultDetail(String gosiCd, String rstNo) {
+        GosiRstMst master = gosiRstMstRepository.findById(new GosiRstMstId(gosiCd, rstNo))
+                .orElseThrow(() -> new EntityNotFoundException("성적을 찾을 수 없습니다: " + gosiCd + "/" + rstNo));
+
+        List<GosiRstSbj> subjects = gosiRstSbjRepository.findByGosiCdAndRstNoOrderBySubjectCd(gosiCd, rstNo);
+        List<GosiRstDet> details = gosiRstDetRepository.findByGosiCdAndRstNoOrderBySubjectCdAscItemNoAsc(gosiCd, rstNo);
+
+        return GosiResultDto.RstDetailResponse.builder()
+                .master(toRstMstResponse(master))
+                .subjects(subjects.stream().map(this::toRstSbjResponse).collect(Collectors.toList()))
+                .details(details.stream().map(this::toRstDetResponse).collect(Collectors.toList()))
+                .build();
+    }
+
+    private GosiResultDto.RstMstResponse toRstMstResponse(GosiRstMst entity) {
+        return GosiResultDto.RstMstResponse.builder()
+                .gosiCd(entity.getGosiCd())
+                .rstNo(entity.getRstNo())
+                .userId(entity.getUserId())
+                .gosiType(entity.getGosiType())
+                .gosiArea(entity.getGosiArea())
+                .totalScore(entity.getTotalScore())
+                .avgScore(entity.getAvgScore())
+                .passYn(entity.getPassYn())
+                .regDt(entity.getRegDt())
+                .build();
+    }
+
+    private GosiResultDto.RstDetResponse toRstDetResponse(GosiRstDet entity) {
+        return GosiResultDto.RstDetResponse.builder()
+                .gosiCd(entity.getGosiCd())
+                .rstNo(entity.getRstNo())
+                .subjectCd(entity.getSubjectCd())
+                .itemNo(entity.getItemNo())
+                .userId(entity.getUserId())
+                .answerData(entity.getAnswerData())
+                .isCorrect(entity.getIsCorrect())
+                .regDt(entity.getRegDt())
+                .build();
+    }
+
+    private GosiResultDto.RstSbjResponse toRstSbjResponse(GosiRstSbj entity) {
+        return GosiResultDto.RstSbjResponse.builder()
+                .gosiCd(entity.getGosiCd())
+                .rstNo(entity.getRstNo())
+                .subjectCd(entity.getSubjectCd())
+                .subjectNm(entity.getSubjectNm())
+                .score(entity.getScore())
+                .correctCnt(entity.getCorrectCnt())
+                .totalCnt(entity.getTotalCnt())
+                .build();
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/service/GosiStatService.java
+++ b/api/src/main/java/com/hopenvision/admin/service/GosiStatService.java
@@ -1,0 +1,86 @@
+package com.hopenvision.admin.service;
+
+import com.hopenvision.admin.dto.GosiStatDto;
+import com.hopenvision.admin.entity.GosiSbjMst;
+import com.hopenvision.admin.entity.GosiStatMst;
+import com.hopenvision.admin.repository.GosiSbjMstRepository;
+import com.hopenvision.admin.repository.GosiStatMstRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class GosiStatService {
+
+    private final GosiStatMstRepository gosiStatMstRepository;
+    private final GosiSbjMstRepository gosiSbjMstRepository;
+
+    /**
+     * 통계 목록 조회 (페이징)
+     */
+    public Page<GosiStatDto.StatMstResponse> getStatList(GosiStatDto.SearchRequest request) {
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+        return gosiStatMstRepository.search(
+                request.getGosiCd(),
+                request.getGosiType(),
+                pageable
+        ).map(this::toStatMstResponse);
+    }
+
+    /**
+     * 대시보드용 통계 전체 조회
+     */
+    public List<GosiStatDto.StatMstResponse> getDashboard(String gosiCd) {
+        return gosiStatMstRepository.findByGosiCdOrderByGosiTypeAscGosiAreaAsc(gosiCd).stream()
+                .map(this::toStatMstResponse)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 과목 구분 목록 조회
+     */
+    public List<GosiStatDto.SbjMstResponse> getSbjMstList(String gosiCd) {
+        return gosiSbjMstRepository.findByGosiCdOrderBySbjTypeAscSubjectCdAsc(gosiCd).stream()
+                .map(this::toSbjMstResponse)
+                .collect(Collectors.toList());
+    }
+
+    private GosiStatDto.StatMstResponse toStatMstResponse(GosiStatMst entity) {
+        return GosiStatDto.StatMstResponse.builder()
+                .gosiCd(entity.getGosiCd())
+                .gosiType(entity.getGosiType())
+                .gosiArea(entity.getGosiArea())
+                .gosiSubjectCd(entity.getGosiSubjectCd())
+                .gosiTypeNm(entity.getGosiTypeNm())
+                .gosiAreaNm(entity.getGosiAreaNm())
+                .gosiSubjectNm(entity.getGosiSubjectNm())
+                .totalCnt(entity.getTotalCnt())
+                .avgScore(entity.getAvgScore())
+                .maxScore(entity.getMaxScore())
+                .minScore(entity.getMinScore())
+                .passCnt(entity.getPassCnt())
+                .passRate(entity.getPassRate())
+                .build();
+    }
+
+    private GosiStatDto.SbjMstResponse toSbjMstResponse(GosiSbjMst entity) {
+        return GosiStatDto.SbjMstResponse.builder()
+                .gosiCd(entity.getGosiCd())
+                .sbjType(entity.getSbjType())
+                .subjectCd(entity.getSubjectCd())
+                .subjectNm(entity.getSubjectNm())
+                .isuse(entity.getIsuse())
+                .pos(entity.getPos())
+                .build();
+    }
+}

--- a/api/src/main/java/com/hopenvision/admin/service/GosiSubjectService.java
+++ b/api/src/main/java/com/hopenvision/admin/service/GosiSubjectService.java
@@ -1,0 +1,79 @@
+package com.hopenvision.admin.service;
+
+import com.hopenvision.admin.dto.GosiSubjectDto;
+import com.hopenvision.admin.dto.GosiVodDto;
+import com.hopenvision.admin.entity.GosiSubject;
+import com.hopenvision.admin.entity.GosiVod;
+import com.hopenvision.admin.repository.GosiSubjectRepository;
+import com.hopenvision.admin.repository.GosiVodRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class GosiSubjectService {
+
+    private final GosiSubjectRepository gosiSubjectRepository;
+    private final GosiVodRepository gosiVodRepository;
+
+    /**
+     * 과목 목록 조회
+     */
+    public List<GosiSubjectDto.Response> getSubjectList(String gosiType) {
+        List<GosiSubject> subjects;
+        if (gosiType != null && !gosiType.isEmpty()) {
+            subjects = gosiSubjectRepository.findByGosiTypeOrderByPos(gosiType);
+        } else {
+            subjects = gosiSubjectRepository.findAll();
+        }
+        return subjects.stream()
+                .map(this::toSubjectResponse)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * VOD 목록 조회 (페이징)
+     */
+    public Page<GosiVodDto.Response> getVodList(GosiVodDto.SearchRequest request) {
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+        return gosiVodRepository.search(
+                request.getGosiCd(),
+                request.getKeyword(),
+                pageable
+        ).map(this::toVodResponse);
+    }
+
+    private GosiSubjectDto.Response toSubjectResponse(GosiSubject entity) {
+        return GosiSubjectDto.Response.builder()
+                .gosiType(entity.getGosiType())
+                .gosiSubjectCd(entity.getGosiSubjectCd())
+                .gosiSubjecNm(entity.getGosiSubjecNm())
+                .isuse(entity.getIsuse())
+                .pos(entity.getPos())
+                .build();
+    }
+
+    private GosiVodDto.Response toVodResponse(GosiVod entity) {
+        return GosiVodDto.Response.builder()
+                .gosiCd(entity.getGosiCd())
+                .prfId(entity.getPrfId())
+                .idx(entity.getIdx())
+                .subjectCd(entity.getSubjectCd())
+                .subjectNm(entity.getSubjectNm())
+                .prfNm(entity.getPrfNm())
+                .vodUrl(entity.getVodUrl())
+                .vodNm(entity.getVodNm())
+                .isuse(entity.getIsuse())
+                .build();
+    }
+}

--- a/api/src/main/java/com/hopenvision/exam/service/ExamService.java
+++ b/api/src/main/java/com/hopenvision/exam/service/ExamService.java
@@ -108,13 +108,13 @@ public class ExamService {
                 .isUse(request.getIsUse() != null ? request.getIsUse() : "Y")
                 .build();
 
-        exam = examRepository.save(exam);
+        Exam savedExam = examRepository.save(exam);
 
         // 과목 일괄 등록
         if (request.getSubjects() != null && !request.getSubjects().isEmpty()) {
             List<ExamSubject> subjects = request.getSubjects().stream()
                     .map(subjectReq -> ExamSubject.builder()
-                            .examCd(exam.getExamCd())
+                            .examCd(savedExam.getExamCd())
                             .subjectCd(subjectReq.getSubjectCd())
                             .subjectNm(subjectReq.getSubjectNm())
                             .subjectType(subjectReq.getSubjectType())
@@ -129,7 +129,7 @@ public class ExamService {
             subjectRepository.saveAll(subjects);
         }
 
-        return toResponse(exam);
+        return toResponse(savedExam);
     }
 
     /**

--- a/scripts/cleanup_gosi_duplicates.sql
+++ b/scripts/cleanup_gosi_duplicates.sql
@@ -1,0 +1,36 @@
+-- 중복 데이터 정리 스크립트
+-- gosi_rst_det: 420건 중복, gosi_vod: 1건 중복 제거
+
+-- 1. gosi_rst_det 중복 제거 (ctid 활용)
+DELETE FROM gosi_rst_det a
+USING gosi_rst_det b
+WHERE a.ctid < b.ctid
+  AND a.gosi_cd = b.gosi_cd
+  AND a.rst_no = b.rst_no
+  AND a.subject_cd = b.subject_cd
+  AND a.item_no = b.item_no;
+
+-- 2. gosi_vod 중복 제거
+DELETE FROM gosi_vod a
+USING gosi_vod b
+WHERE a.ctid < b.ctid
+  AND a.gosi_cd = b.gosi_cd
+  AND a.prf_id = b.prf_id
+  AND a.idx = b.idx;
+
+-- 3. PK 제약조건 추가
+ALTER TABLE gosi_rst_det ADD PRIMARY KEY (gosi_cd, rst_no, subject_cd, item_no);
+ALTER TABLE gosi_vod ADD PRIMARY KEY (gosi_cd, prf_id, idx);
+
+-- 4. 기타 테이블 PK 추가
+ALTER TABLE gosi_mst ADD PRIMARY KEY (gosi_cd);
+ALTER TABLE gosi_cod ADD PRIMARY KEY (gosi_type);
+ALTER TABLE gosi_area_mst ADD PRIMARY KEY (gosi_type, gosi_area);
+ALTER TABLE gosi_subject ADD PRIMARY KEY (gosi_type, gosi_subject_cd);
+ALTER TABLE gosi_pass_mst ADD PRIMARY KEY (gosi_cd, subject_cd, exam_type, item_no);
+ALTER TABLE gosi_pass_sta ADD PRIMARY KEY (gosi_cd, gosi_type);
+ALTER TABLE gosi_rst_mst ADD PRIMARY KEY (gosi_cd, rst_no);
+ALTER TABLE gosi_rst_sbj ADD PRIMARY KEY (gosi_cd, rst_no, subject_cd);
+ALTER TABLE gosi_stat_mst ADD PRIMARY KEY (gosi_cd, gosi_type, gosi_area, gosi_subject_cd);
+ALTER TABLE gosi_sbj_mst ADD PRIMARY KEY (gosi_cd, sbj_type, subject_cd);
+ALTER TABLE tb_ma_member ADD PRIMARY KEY (user_id);

--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -13,6 +13,13 @@ import ExcelImport from './pages/ExcelImport';
 import JsonImport from './pages/JsonImport';
 import ApplicantList from './pages/ApplicantList';
 import Statistics from './pages/Statistics';
+import GosiExamList from './pages/gosi/GosiExamList';
+import GosiPassList from './pages/gosi/GosiPassList';
+import GosiScoreList from './pages/gosi/GosiScoreList';
+import GosiScoreDetail from './pages/gosi/GosiScoreDetail';
+import GosiStatistics from './pages/gosi/GosiStatistics';
+import GosiSubjectList from './pages/gosi/GosiSubjectList';
+import GosiMemberList from './pages/gosi/GosiMemberList';
 import './App.css';
 
 const queryClient = new QueryClient({
@@ -47,6 +54,13 @@ function App() {
                 <Route path="applicants" element={<ApplicantList />} />
                 <Route path="statistics" element={<Statistics />} />
                 <Route path="import/preview" element={<ExcelImport />} />
+                <Route path="gosi/exams" element={<GosiExamList />} />
+                <Route path="gosi/pass" element={<GosiPassList />} />
+                <Route path="gosi/results" element={<GosiScoreList />} />
+                <Route path="gosi/results/:gosiCd/:rstNo" element={<GosiScoreDetail />} />
+                <Route path="gosi/statistics" element={<GosiStatistics />} />
+                <Route path="gosi/subjects" element={<GosiSubjectList />} />
+                <Route path="gosi/members" element={<GosiMemberList />} />
                 <Route path="*" element={<Navigate to="/exams" replace />} />
               </Route>
             </Routes>

--- a/web-admin/src/api/gosiApi.ts
+++ b/web-admin/src/api/gosiApi.ts
@@ -1,0 +1,126 @@
+import { adminClient as client } from './adminClient';
+import type { ApiResponse, PageResponse } from '@hopenvision/shared';
+import type {
+  GosiMstResponse,
+  GosiCodResponse,
+  GosiAreaResponse,
+  GosiSubjectResponse,
+  GosiPassMstResponse,
+  GosiPassStaResponse,
+  GosiRstMstResponse,
+  GosiRstDetailResponse,
+  GosiStatMstResponse,
+  GosiSbjMstResponse,
+  GosiVodResponse,
+  GosiMemberResponse,
+} from '../types/gosi';
+
+export const gosiApi = {
+  // === 시험 관리 ===
+  getExamList: async (): Promise<ApiResponse<GosiMstResponse[]>> => {
+    const response = await client.get('/api/gosi/exams');
+    return response.data;
+  },
+
+  getExamDetail: async (gosiCd: string): Promise<ApiResponse<GosiMstResponse>> => {
+    const response = await client.get(`/api/gosi/exams/${gosiCd}`);
+    return response.data;
+  },
+
+  getTypeList: async (): Promise<ApiResponse<GosiCodResponse[]>> => {
+    const response = await client.get('/api/gosi/exams/types');
+    return response.data;
+  },
+
+  getAreaList: async (gosiType?: string): Promise<ApiResponse<GosiAreaResponse[]>> => {
+    const response = await client.get('/api/gosi/exams/areas', { params: { gosiType } });
+    return response.data;
+  },
+
+  // === 정답 관리 ===
+  getPassList: async (params: {
+    gosiCd: string;
+    subjectCd?: string;
+    examType?: string;
+    page?: number;
+    size?: number;
+  }): Promise<ApiResponse<PageResponse<GosiPassMstResponse>>> => {
+    const response = await client.get('/api/gosi/pass', { params });
+    return response.data;
+  },
+
+  getPassStaList: async (gosiCd: string): Promise<ApiResponse<GosiPassStaResponse[]>> => {
+    const response = await client.get('/api/gosi/pass/standards', { params: { gosiCd } });
+    return response.data;
+  },
+
+  // === 성적 관리 ===
+  getResultList: async (params: {
+    gosiCd: string;
+    gosiType?: string;
+    gosiArea?: string;
+    keyword?: string;
+    page?: number;
+    size?: number;
+  }): Promise<ApiResponse<PageResponse<GosiRstMstResponse>>> => {
+    const response = await client.get('/api/gosi/results', { params });
+    return response.data;
+  },
+
+  getResultDetail: async (gosiCd: string, rstNo: string): Promise<ApiResponse<GosiRstDetailResponse>> => {
+    const response = await client.get(`/api/gosi/results/${gosiCd}/${rstNo}`);
+    return response.data;
+  },
+
+  // === 통계 ===
+  getStatList: async (params: {
+    gosiCd: string;
+    gosiType?: string;
+    page?: number;
+    size?: number;
+  }): Promise<ApiResponse<PageResponse<GosiStatMstResponse>>> => {
+    const response = await client.get('/api/gosi/statistics', { params });
+    return response.data;
+  },
+
+  getDashboard: async (gosiCd: string): Promise<ApiResponse<GosiStatMstResponse[]>> => {
+    const response = await client.get('/api/gosi/statistics/dashboard', { params: { gosiCd } });
+    return response.data;
+  },
+
+  getSbjMstList: async (gosiCd: string): Promise<ApiResponse<GosiSbjMstResponse[]>> => {
+    const response = await client.get('/api/gosi/statistics/subjects', { params: { gosiCd } });
+    return response.data;
+  },
+
+  // === 과목/VOD ===
+  getSubjectList: async (gosiType?: string): Promise<ApiResponse<GosiSubjectResponse[]>> => {
+    const response = await client.get('/api/gosi/subjects', { params: { gosiType } });
+    return response.data;
+  },
+
+  getVodList: async (params: {
+    gosiCd?: string;
+    keyword?: string;
+    page?: number;
+    size?: number;
+  }): Promise<ApiResponse<PageResponse<GosiVodResponse>>> => {
+    const response = await client.get('/api/gosi/subjects/vods', { params });
+    return response.data;
+  },
+
+  // === 회원 관리 ===
+  getMemberList: async (params: {
+    keyword?: string;
+    page?: number;
+    size?: number;
+  }): Promise<ApiResponse<PageResponse<GosiMemberResponse>>> => {
+    const response = await client.get('/api/gosi/members', { params });
+    return response.data;
+  },
+
+  getMemberDetail: async (userId: string): Promise<ApiResponse<GosiMemberResponse>> => {
+    const response = await client.get(`/api/gosi/members/${userId}`);
+    return response.data;
+  },
+};

--- a/web-admin/src/components/AdminLayout.tsx
+++ b/web-admin/src/components/AdminLayout.tsx
@@ -6,6 +6,7 @@ import {
   UserOutlined,
   BarChartOutlined,
   LogoutOutlined,
+  TrophyOutlined,
 } from '@ant-design/icons';
 import { useAuth } from '../auth/useAuth';
 
@@ -27,6 +28,19 @@ const menuItems = [
     icon: <BarChartOutlined />,
     label: '통계',
   },
+  {
+    key: 'gosi',
+    icon: <TrophyOutlined />,
+    label: '합격예측',
+    children: [
+      { key: '/gosi/exams', label: '시험/지역 관리' },
+      { key: '/gosi/pass', label: '정답 관리' },
+      { key: '/gosi/results', label: '성적 관리' },
+      { key: '/gosi/statistics', label: '통계' },
+      { key: '/gosi/subjects', label: '과목/VOD' },
+      { key: '/gosi/members', label: '회원 관리' },
+    ],
+  },
 ];
 
 export default function AdminLayout() {
@@ -42,10 +56,22 @@ export default function AdminLayout() {
 
   const getSelectedKey = () => {
     const path = location.pathname;
+    if (path.startsWith('/gosi/exams')) return '/gosi/exams';
+    if (path.startsWith('/gosi/pass')) return '/gosi/pass';
+    if (path.startsWith('/gosi/results')) return '/gosi/results';
+    if (path.startsWith('/gosi/statistics')) return '/gosi/statistics';
+    if (path.startsWith('/gosi/subjects')) return '/gosi/subjects';
+    if (path.startsWith('/gosi/members')) return '/gosi/members';
     if (path.startsWith('/exams')) return '/exams';
     if (path.startsWith('/applicants')) return '/applicants';
     if (path.startsWith('/statistics')) return '/statistics';
     return '/exams';
+  };
+
+  const getOpenKeys = () => {
+    const path = location.pathname;
+    if (path.startsWith('/gosi')) return ['gosi'];
+    return [];
   };
 
   const handleLogout = () => {
@@ -77,6 +103,7 @@ export default function AdminLayout() {
         <Menu
           mode="inline"
           selectedKeys={[getSelectedKey()]}
+          defaultOpenKeys={getOpenKeys()}
           items={menuItems}
           onClick={handleMenuClick}
           style={{ borderRight: 0 }}

--- a/web-admin/src/pages/gosi/GosiExamList.tsx
+++ b/web-admin/src/pages/gosi/GosiExamList.tsx
@@ -1,0 +1,150 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Table, Card, Tag, Select, Space, Descriptions } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { gosiApi } from '../../api/gosiApi';
+import type { GosiMstResponse, GosiCodResponse, GosiAreaResponse } from '../../types/gosi';
+
+export default function GosiExamList() {
+  const [selectedType, setSelectedType] = useState<string>('');
+
+  // 시험 목록
+  const { data: examData, isLoading: examLoading } = useQuery({
+    queryKey: ['gosi-exams'],
+    queryFn: () => gosiApi.getExamList(),
+  });
+
+  // 시험 유형 목록
+  const { data: typeData } = useQuery({
+    queryKey: ['gosi-types'],
+    queryFn: () => gosiApi.getTypeList(),
+  });
+
+  // 지역 목록
+  const { data: areaData, isLoading: areaLoading } = useQuery({
+    queryKey: ['gosi-areas', selectedType],
+    queryFn: () => gosiApi.getAreaList(selectedType || undefined),
+  });
+
+  const examColumns: ColumnsType<GosiMstResponse> = [
+    { title: '시험코드', dataIndex: 'gosiCd', key: 'gosiCd', width: 120 },
+    { title: '시험명', dataIndex: 'gosiNm', key: 'gosiNm' },
+    { title: '시험유형', dataIndex: 'gosiType', key: 'gosiType', width: 100 },
+    { title: '년도', dataIndex: 'gosiYear', key: 'gosiYear', width: 80 },
+    { title: '회차', dataIndex: 'gosiRound', key: 'gosiRound', width: 80 },
+    {
+      title: '총점', dataIndex: 'totalScore', key: 'totalScore', width: 80, align: 'center',
+      render: (v) => v != null ? `${v}점` : '-',
+    },
+    {
+      title: '합격점', dataIndex: 'passScore', key: 'passScore', width: 80, align: 'center',
+      render: (v) => v != null ? `${v}점` : '-',
+    },
+    {
+      title: '사용', dataIndex: 'isuse', key: 'isuse', width: 70, align: 'center',
+      render: (v) => <Tag color={v === 'Y' ? 'green' : 'red'}>{v === 'Y' ? '사용' : '미사용'}</Tag>,
+    },
+    {
+      title: '시작일', dataIndex: 'startDt', key: 'startDt', width: 150,
+      render: (v) => v?.substring(0, 16),
+    },
+  ];
+
+  const typeColumns: ColumnsType<GosiCodResponse> = [
+    { title: '유형코드', dataIndex: 'gosiType', key: 'gosiType', width: 120 },
+    { title: '유형명', dataIndex: 'gosiTypeNm', key: 'gosiTypeNm' },
+    {
+      title: '사용', dataIndex: 'isuse', key: 'isuse', width: 70, align: 'center',
+      render: (v) => <Tag color={v === 'Y' ? 'green' : 'red'}>{v === 'Y' ? '사용' : '미사용'}</Tag>,
+    },
+    { title: '순서', dataIndex: 'pos', key: 'pos', width: 70, align: 'center' },
+  ];
+
+  const areaColumns: ColumnsType<GosiAreaResponse> = [
+    { title: '유형', dataIndex: 'gosiType', key: 'gosiType', width: 100 },
+    { title: '지역코드', dataIndex: 'gosiArea', key: 'gosiArea', width: 120 },
+    { title: '지역명', dataIndex: 'gosiAreaNm', key: 'gosiAreaNm' },
+    {
+      title: '사용', dataIndex: 'isuse', key: 'isuse', width: 70, align: 'center',
+      render: (v) => <Tag color={v === 'Y' ? 'green' : 'red'}>{v === 'Y' ? '사용' : '미사용'}</Tag>,
+    },
+    { title: '순서', dataIndex: 'pos', key: 'pos', width: 70, align: 'center' },
+  ];
+
+  const exams = examData?.data || [];
+  const exam = exams.length > 0 ? exams[0] : null;
+
+  return (
+    <div>
+      {exam && (
+        <Card title="시험 정보" style={{ marginBottom: 16 }}>
+          <Descriptions column={3} size="small">
+            <Descriptions.Item label="시험코드">{exam.gosiCd}</Descriptions.Item>
+            <Descriptions.Item label="시험명">{exam.gosiNm}</Descriptions.Item>
+            <Descriptions.Item label="시험유형">{exam.gosiType}</Descriptions.Item>
+            <Descriptions.Item label="년도/회차">{exam.gosiYear} / {exam.gosiRound}</Descriptions.Item>
+            <Descriptions.Item label="총점">{exam.totalScore}점</Descriptions.Item>
+            <Descriptions.Item label="합격점">{exam.passScore}점</Descriptions.Item>
+          </Descriptions>
+        </Card>
+      )}
+
+      <Card
+        title={`시험 목록 (${exams.length}건)`}
+        style={{ marginBottom: 16 }}
+      >
+        <Table
+          columns={examColumns}
+          dataSource={exams}
+          rowKey="gosiCd"
+          loading={examLoading}
+          pagination={false}
+          size="small"
+          scroll={{ x: 1000 }}
+        />
+      </Card>
+
+      <Card
+        title={`시험 유형 (${typeData?.data?.length || 0}건)`}
+        style={{ marginBottom: 16 }}
+      >
+        <Table
+          columns={typeColumns}
+          dataSource={typeData?.data || []}
+          rowKey="gosiType"
+          pagination={false}
+          size="small"
+        />
+      </Card>
+
+      <Card
+        title={
+          <Space>
+            <span>지역 목록 ({areaData?.data?.length || 0}건)</span>
+            <Select
+              placeholder="시험유형 필터"
+              allowClear
+              style={{ width: 160 }}
+              value={selectedType || undefined}
+              onChange={(v) => setSelectedType(v || '')}
+              options={(typeData?.data || []).map((t) => ({
+                value: t.gosiType,
+                label: t.gosiTypeNm,
+              }))}
+            />
+          </Space>
+        }
+      >
+        <Table
+          columns={areaColumns}
+          dataSource={areaData?.data || []}
+          rowKey={(r) => `${r.gosiType}-${r.gosiArea}`}
+          loading={areaLoading}
+          pagination={false}
+          size="small"
+          scroll={{ x: 600 }}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/web-admin/src/pages/gosi/GosiMemberList.tsx
+++ b/web-admin/src/pages/gosi/GosiMemberList.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Table, Card, Input, Button, Space, Tag, Modal, Descriptions } from 'antd';
+import { SearchOutlined, ReloadOutlined, EyeOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { gosiApi } from '../../api/gosiApi';
+import type { GosiMemberResponse } from '../../types/gosi';
+
+export default function GosiMemberList() {
+  const [searchParams, setSearchParams] = useState({
+    keyword: '',
+    page: 0,
+    size: 20,
+  });
+  const [detailModal, setDetailModal] = useState<GosiMemberResponse | null>(null);
+
+  // 회원 목록
+  const { data, isLoading } = useQuery({
+    queryKey: ['gosi-members', searchParams],
+    queryFn: () => gosiApi.getMemberList(searchParams),
+  });
+
+  const handleReset = () => {
+    setSearchParams({ keyword: '', page: 0, size: 20 });
+  };
+
+  const columns: ColumnsType<GosiMemberResponse> = [
+    { title: '사용자ID', dataIndex: 'userId', key: 'userId', width: 120 },
+    { title: '이름', dataIndex: 'userNm', key: 'userNm', width: 120 },
+    { title: '닉네임', dataIndex: 'userNicknm', key: 'userNicknm', width: 120 },
+    { title: '직급', dataIndex: 'userPosition', key: 'userPosition', width: 100 },
+    {
+      title: '성별', dataIndex: 'sex', key: 'sex', width: 70, align: 'center',
+      render: (v) => v === 'M' ? '남' : v === 'F' ? '여' : v || '-',
+    },
+    { title: '역할', dataIndex: 'userRole', key: 'userRole', width: 100 },
+    {
+      title: '포인트', dataIndex: 'userPoint', key: 'userPoint', width: 80, align: 'right',
+      render: (v) => v != null ? v.toLocaleString() : '-',
+    },
+    {
+      title: '사용', dataIndex: 'isuse', key: 'isuse', width: 70, align: 'center',
+      render: (v) => <Tag color={v === 'Y' ? 'green' : 'red'}>{v === 'Y' ? '사용' : '미사용'}</Tag>,
+    },
+    {
+      title: '관리', key: 'action', width: 80, align: 'center',
+      render: (_, record) => (
+        <Button
+          size="small"
+          icon={<EyeOutlined />}
+          onClick={() => setDetailModal(record)}
+        >
+          상세
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <Card style={{ marginBottom: 16 }}>
+        <Space>
+          <Input
+            placeholder="사용자ID, 이름, 닉네임 검색"
+            value={searchParams.keyword}
+            onChange={(e) => setSearchParams((prev) => ({ ...prev, keyword: e.target.value }))}
+            onPressEnter={() => setSearchParams((prev) => ({ ...prev, page: 0 }))}
+            style={{ width: 300 }}
+          />
+          <Button icon={<SearchOutlined />} type="primary"
+            onClick={() => setSearchParams((prev) => ({ ...prev, page: 0 }))}>
+            검색
+          </Button>
+          <Button icon={<ReloadOutlined />} onClick={handleReset}>초기화</Button>
+        </Space>
+      </Card>
+
+      <Card title={<span>회원 목록 (총 <strong>{data?.data?.totalElements || 0}</strong>건)</span>}>
+        <Table
+          columns={columns}
+          dataSource={data?.data?.content || []}
+          rowKey="userId"
+          loading={isLoading}
+          pagination={{
+            current: searchParams.page + 1,
+            pageSize: searchParams.size,
+            total: data?.data?.totalElements || 0,
+            showSizeChanger: true,
+            showTotal: (total) => `총 ${total}건`,
+            onChange: (page, pageSize) => {
+              setSearchParams((prev) => ({ ...prev, page: page - 1, size: pageSize }));
+            },
+          }}
+          size="small"
+          scroll={{ x: 900 }}
+        />
+      </Card>
+
+      <Modal
+        title="회원 상세 정보"
+        open={!!detailModal}
+        onCancel={() => setDetailModal(null)}
+        footer={null}
+        width={600}
+      >
+        {detailModal && (
+          <Descriptions column={2} size="small" bordered>
+            <Descriptions.Item label="사용자ID">{detailModal.userId}</Descriptions.Item>
+            <Descriptions.Item label="이름">{detailModal.userNm}</Descriptions.Item>
+            <Descriptions.Item label="닉네임">{detailModal.userNicknm || '-'}</Descriptions.Item>
+            <Descriptions.Item label="직급">{detailModal.userPosition || '-'}</Descriptions.Item>
+            <Descriptions.Item label="성별">
+              {detailModal.sex === 'M' ? '남' : detailModal.sex === 'F' ? '여' : detailModal.sex || '-'}
+            </Descriptions.Item>
+            <Descriptions.Item label="역할">{detailModal.userRole || '-'}</Descriptions.Item>
+            <Descriptions.Item label="관리자역할">{detailModal.adminRole || '-'}</Descriptions.Item>
+            <Descriptions.Item label="생년월일">{detailModal.birthDay?.substring(0, 10) || '-'}</Descriptions.Item>
+            <Descriptions.Item label="카테고리">{detailModal.categoryCode || '-'}</Descriptions.Item>
+            <Descriptions.Item label="포인트">{detailModal.userPoint?.toLocaleString() || '-'}</Descriptions.Item>
+            <Descriptions.Item label="결제">{detailModal.payment?.toLocaleString() || '-'}</Descriptions.Item>
+            <Descriptions.Item label="사용여부">
+              <Tag color={detailModal.isuse === 'Y' ? 'green' : 'red'}>
+                {detailModal.isuse === 'Y' ? '사용' : '미사용'}
+              </Tag>
+            </Descriptions.Item>
+          </Descriptions>
+        )}
+      </Modal>
+    </div>
+  );
+}

--- a/web-admin/src/pages/gosi/GosiPassList.tsx
+++ b/web-admin/src/pages/gosi/GosiPassList.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Table, Card, Select, Row, Col, Input, Button, Space, Tag } from 'antd';
+import { SearchOutlined, ReloadOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { gosiApi } from '../../api/gosiApi';
+import type { GosiPassMstResponse, GosiPassStaResponse } from '../../types/gosi';
+
+export default function GosiPassList() {
+  const [searchParams, setSearchParams] = useState({
+    gosiCd: '',
+    subjectCd: '',
+    examType: '',
+    page: 0,
+    size: 20,
+  });
+
+  // 시험 목록 (gosiCd 선택용)
+  const { data: examData } = useQuery({
+    queryKey: ['gosi-exams'],
+    queryFn: () => gosiApi.getExamList(),
+  });
+
+  // 정답 목록
+  const { data, isLoading } = useQuery({
+    queryKey: ['gosi-pass', searchParams],
+    queryFn: () => gosiApi.getPassList(searchParams),
+    enabled: !!searchParams.gosiCd,
+  });
+
+  // 합격선
+  const { data: staData } = useQuery({
+    queryKey: ['gosi-pass-sta', searchParams.gosiCd],
+    queryFn: () => gosiApi.getPassStaList(searchParams.gosiCd),
+    enabled: !!searchParams.gosiCd,
+  });
+
+  const handleReset = () => {
+    setSearchParams({ gosiCd: '', subjectCd: '', examType: '', page: 0, size: 20 });
+  };
+
+  const passColumns: ColumnsType<GosiPassMstResponse> = [
+    { title: '과목코드', dataIndex: 'subjectCd', key: 'subjectCd', width: 100 },
+    { title: '과목명', dataIndex: 'subjectNm', key: 'subjectNm', width: 150 },
+    { title: '시험유형', dataIndex: 'examType', key: 'examType', width: 100 },
+    { title: '문항번호', dataIndex: 'itemNo', key: 'itemNo', width: 90, align: 'center' },
+    {
+      title: '정답', dataIndex: 'answerData', key: 'answerData', width: 80, align: 'center',
+      render: (v) => <Tag color="blue">{v}</Tag>,
+    },
+  ];
+
+  const staColumns: ColumnsType<GosiPassStaResponse> = [
+    { title: '시험유형', dataIndex: 'gosiType', key: 'gosiType', width: 100 },
+    { title: '유형명', dataIndex: 'gosiTypeNm', key: 'gosiTypeNm' },
+    {
+      title: '합격점수', dataIndex: 'passScore', key: 'passScore', width: 100, align: 'center',
+      render: (v) => v != null ? `${v}점` : '-',
+    },
+    {
+      title: '사용', dataIndex: 'isuse', key: 'isuse', width: 70, align: 'center',
+      render: (v) => <Tag color={v === 'Y' ? 'green' : 'red'}>{v === 'Y' ? '사용' : '미사용'}</Tag>,
+    },
+  ];
+
+  return (
+    <div>
+      <Card style={{ marginBottom: 16 }}>
+        <Row gutter={[16, 16]} align="middle">
+          <Col>
+            <Select
+              placeholder="시험 선택"
+              style={{ width: 200 }}
+              value={searchParams.gosiCd || undefined}
+              onChange={(v) => setSearchParams((prev) => ({ ...prev, gosiCd: v || '', page: 0 }))}
+              options={(examData?.data || []).map((e) => ({
+                value: e.gosiCd,
+                label: e.gosiNm || e.gosiCd,
+              }))}
+            />
+          </Col>
+          <Col>
+            <Input
+              placeholder="과목코드"
+              style={{ width: 120 }}
+              value={searchParams.subjectCd}
+              onChange={(e) => setSearchParams((prev) => ({ ...prev, subjectCd: e.target.value }))}
+            />
+          </Col>
+          <Col>
+            <Input
+              placeholder="시험유형"
+              style={{ width: 120 }}
+              value={searchParams.examType}
+              onChange={(e) => setSearchParams((prev) => ({ ...prev, examType: e.target.value }))}
+            />
+          </Col>
+          <Col>
+            <Space>
+              <Button icon={<SearchOutlined />} type="primary"
+                onClick={() => setSearchParams((prev) => ({ ...prev, page: 0 }))}>
+                검색
+              </Button>
+              <Button icon={<ReloadOutlined />} onClick={handleReset}>초기화</Button>
+            </Space>
+          </Col>
+        </Row>
+      </Card>
+
+      {searchParams.gosiCd && staData?.data && staData.data.length > 0 && (
+        <Card title="합격선" style={{ marginBottom: 16 }}>
+          <Table
+            columns={staColumns}
+            dataSource={staData.data}
+            rowKey={(r) => `${r.gosiCd}-${r.gosiType}`}
+            pagination={false}
+            size="small"
+          />
+        </Card>
+      )}
+
+      <Card
+        title={<span>정답 목록 (총 <strong>{data?.data?.totalElements || 0}</strong>건)</span>}
+      >
+        <Table
+          columns={passColumns}
+          dataSource={data?.data?.content || []}
+          rowKey={(r) => `${r.gosiCd}-${r.subjectCd}-${r.examType}-${r.itemNo}`}
+          loading={isLoading}
+          pagination={{
+            current: searchParams.page + 1,
+            pageSize: searchParams.size,
+            total: data?.data?.totalElements || 0,
+            showSizeChanger: true,
+            showTotal: (total) => `총 ${total}건`,
+            onChange: (page, pageSize) => {
+              setSearchParams((prev) => ({ ...prev, page: page - 1, size: pageSize }));
+            },
+          }}
+          size="small"
+          scroll={{ x: 600 }}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/web-admin/src/pages/gosi/GosiScoreDetail.tsx
+++ b/web-admin/src/pages/gosi/GosiScoreDetail.tsx
@@ -1,0 +1,97 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Card, Descriptions, Table, Tag, Button, Spin } from 'antd';
+import { ArrowLeftOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { gosiApi } from '../../api/gosiApi';
+import type { GosiRstSbjResponse, GosiRstDetResponse } from '../../types/gosi';
+
+export default function GosiScoreDetail() {
+  const { gosiCd, rstNo } = useParams<{ gosiCd: string; rstNo: string }>();
+  const navigate = useNavigate();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['gosi-result-detail', gosiCd, rstNo],
+    queryFn: () => gosiApi.getResultDetail(gosiCd!, rstNo!),
+    enabled: !!gosiCd && !!rstNo,
+  });
+
+  if (isLoading) return <Spin size="large" />;
+
+  const detail = data?.data;
+  if (!detail) return <div>데이터를 찾을 수 없습니다.</div>;
+
+  const sbjColumns: ColumnsType<GosiRstSbjResponse> = [
+    { title: '과목코드', dataIndex: 'subjectCd', key: 'subjectCd', width: 100 },
+    { title: '과목명', dataIndex: 'subjectNm', key: 'subjectNm' },
+    {
+      title: '점수', dataIndex: 'score', key: 'score', width: 80, align: 'center',
+      render: (v) => v != null ? `${v}` : '-',
+    },
+    {
+      title: '정답수', dataIndex: 'correctCnt', key: 'correctCnt', width: 80, align: 'center',
+      render: (v, r) => v != null ? `${v}/${r.totalCnt || 0}` : '-',
+    },
+  ];
+
+  const detColumns: ColumnsType<GosiRstDetResponse> = [
+    { title: '과목코드', dataIndex: 'subjectCd', key: 'subjectCd', width: 100 },
+    { title: '문항번호', dataIndex: 'itemNo', key: 'itemNo', width: 90, align: 'center' },
+    { title: '답안', dataIndex: 'answerData', key: 'answerData', width: 80, align: 'center' },
+    {
+      title: '정답여부', dataIndex: 'isCorrect', key: 'isCorrect', width: 90, align: 'center',
+      render: (v) => <Tag color={v === 'Y' ? 'green' : 'red'}>{v === 'Y' ? '정답' : '오답'}</Tag>,
+    },
+  ];
+
+  return (
+    <div>
+      <Button
+        icon={<ArrowLeftOutlined />}
+        onClick={() => navigate('/gosi/results')}
+        style={{ marginBottom: 16 }}
+      >
+        목록으로
+      </Button>
+
+      <Card title="성적 기본 정보" style={{ marginBottom: 16 }}>
+        <Descriptions column={3} size="small">
+          <Descriptions.Item label="시험코드">{detail.master.gosiCd}</Descriptions.Item>
+          <Descriptions.Item label="성적번호">{detail.master.rstNo}</Descriptions.Item>
+          <Descriptions.Item label="사용자ID">{detail.master.userId}</Descriptions.Item>
+          <Descriptions.Item label="시험유형">{detail.master.gosiType}</Descriptions.Item>
+          <Descriptions.Item label="지역">{detail.master.gosiArea}</Descriptions.Item>
+          <Descriptions.Item label="합격여부">
+            <Tag color={detail.master.passYn === 'Y' ? 'green' : 'red'}>
+              {detail.master.passYn === 'Y' ? '합격' : '불합격'}
+            </Tag>
+          </Descriptions.Item>
+          <Descriptions.Item label="총점">{detail.master.totalScore}</Descriptions.Item>
+          <Descriptions.Item label="평균">{detail.master.avgScore}</Descriptions.Item>
+          <Descriptions.Item label="등록일">{detail.master.regDt?.substring(0, 16)}</Descriptions.Item>
+        </Descriptions>
+      </Card>
+
+      <Card title={`과목별 성적 (${detail.subjects.length}건)`} style={{ marginBottom: 16 }}>
+        <Table
+          columns={sbjColumns}
+          dataSource={detail.subjects}
+          rowKey={(r) => `${r.gosiCd}-${r.rstNo}-${r.subjectCd}`}
+          pagination={false}
+          size="small"
+        />
+      </Card>
+
+      <Card title={`답안 상세 (${detail.details.length}건)`}>
+        <Table
+          columns={detColumns}
+          dataSource={detail.details}
+          rowKey={(r) => `${r.gosiCd}-${r.rstNo}-${r.subjectCd}-${r.itemNo}`}
+          pagination={{ pageSize: 50, showSizeChanger: true, showTotal: (t) => `총 ${t}건` }}
+          size="small"
+          scroll={{ x: 500 }}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/web-admin/src/pages/gosi/GosiScoreList.tsx
+++ b/web-admin/src/pages/gosi/GosiScoreList.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Table, Card, Select, Row, Col, Input, Button, Space, Tag } from 'antd';
+import { SearchOutlined, ReloadOutlined, EyeOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { gosiApi } from '../../api/gosiApi';
+import type { GosiRstMstResponse } from '../../types/gosi';
+
+export default function GosiScoreList() {
+  const navigate = useNavigate();
+
+  const [searchParams, setSearchParams] = useState({
+    gosiCd: '',
+    gosiType: '',
+    gosiArea: '',
+    keyword: '',
+    page: 0,
+    size: 20,
+  });
+
+  // 시험 목록
+  const { data: examData } = useQuery({
+    queryKey: ['gosi-exams'],
+    queryFn: () => gosiApi.getExamList(),
+  });
+
+  // 유형 목록
+  const { data: typeData } = useQuery({
+    queryKey: ['gosi-types'],
+    queryFn: () => gosiApi.getTypeList(),
+  });
+
+  // 지역 목록
+  const { data: areaData } = useQuery({
+    queryKey: ['gosi-areas', searchParams.gosiType],
+    queryFn: () => gosiApi.getAreaList(searchParams.gosiType || undefined),
+    enabled: !!searchParams.gosiType,
+  });
+
+  // 성적 목록
+  const { data, isLoading } = useQuery({
+    queryKey: ['gosi-results', searchParams],
+    queryFn: () => gosiApi.getResultList(searchParams),
+    enabled: !!searchParams.gosiCd,
+  });
+
+  const handleReset = () => {
+    setSearchParams({ gosiCd: '', gosiType: '', gosiArea: '', keyword: '', page: 0, size: 20 });
+  };
+
+  const columns: ColumnsType<GosiRstMstResponse> = [
+    { title: '성적번호', dataIndex: 'rstNo', key: 'rstNo', width: 100 },
+    { title: '사용자ID', dataIndex: 'userId', key: 'userId', width: 120 },
+    { title: '시험유형', dataIndex: 'gosiType', key: 'gosiType', width: 100 },
+    { title: '지역', dataIndex: 'gosiArea', key: 'gosiArea', width: 100 },
+    {
+      title: '총점', dataIndex: 'totalScore', key: 'totalScore', width: 80, align: 'center',
+      render: (v) => v != null ? `${v}` : '-',
+    },
+    {
+      title: '평균', dataIndex: 'avgScore', key: 'avgScore', width: 80, align: 'center',
+      render: (v) => v != null ? `${v}` : '-',
+    },
+    {
+      title: '합격', dataIndex: 'passYn', key: 'passYn', width: 70, align: 'center',
+      render: (v) => <Tag color={v === 'Y' ? 'green' : 'red'}>{v === 'Y' ? '합격' : '불합격'}</Tag>,
+    },
+    {
+      title: '등록일', dataIndex: 'regDt', key: 'regDt', width: 150,
+      render: (v) => v?.substring(0, 16),
+    },
+    {
+      title: '관리', key: 'action', width: 80, align: 'center',
+      render: (_, record) => (
+        <Button
+          size="small"
+          icon={<EyeOutlined />}
+          onClick={() => navigate(`/gosi/results/${record.gosiCd}/${record.rstNo}`)}
+        >
+          상세
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <Card style={{ marginBottom: 16 }}>
+        <Row gutter={[16, 16]} align="middle">
+          <Col>
+            <Select
+              placeholder="시험 선택"
+              style={{ width: 200 }}
+              value={searchParams.gosiCd || undefined}
+              onChange={(v) => setSearchParams((prev) => ({ ...prev, gosiCd: v || '', page: 0 }))}
+              options={(examData?.data || []).map((e) => ({
+                value: e.gosiCd,
+                label: e.gosiNm || e.gosiCd,
+              }))}
+            />
+          </Col>
+          <Col>
+            <Select
+              placeholder="시험유형"
+              allowClear
+              style={{ width: 140 }}
+              value={searchParams.gosiType || undefined}
+              onChange={(v) => setSearchParams((prev) => ({ ...prev, gosiType: v || '', gosiArea: '', page: 0 }))}
+              options={(typeData?.data || []).map((t) => ({
+                value: t.gosiType,
+                label: t.gosiTypeNm,
+              }))}
+            />
+          </Col>
+          <Col>
+            <Select
+              placeholder="지역"
+              allowClear
+              style={{ width: 140 }}
+              value={searchParams.gosiArea || undefined}
+              onChange={(v) => setSearchParams((prev) => ({ ...prev, gosiArea: v || '', page: 0 }))}
+              options={(areaData?.data || []).map((a) => ({
+                value: a.gosiArea,
+                label: a.gosiAreaNm,
+              }))}
+              disabled={!searchParams.gosiType}
+            />
+          </Col>
+          <Col flex="auto">
+            <Input
+              placeholder="사용자ID 또는 성적번호 검색"
+              value={searchParams.keyword}
+              onChange={(e) => setSearchParams((prev) => ({ ...prev, keyword: e.target.value }))}
+              onPressEnter={() => setSearchParams((prev) => ({ ...prev, page: 0 }))}
+              style={{ width: 250 }}
+            />
+          </Col>
+          <Col>
+            <Space>
+              <Button icon={<SearchOutlined />} type="primary"
+                onClick={() => setSearchParams((prev) => ({ ...prev, page: 0 }))}>
+                검색
+              </Button>
+              <Button icon={<ReloadOutlined />} onClick={handleReset}>초기화</Button>
+            </Space>
+          </Col>
+        </Row>
+      </Card>
+
+      <Card title={<span>성적 목록 (총 <strong>{data?.data?.totalElements || 0}</strong>건)</span>}>
+        <Table
+          columns={columns}
+          dataSource={data?.data?.content || []}
+          rowKey={(r) => `${r.gosiCd}-${r.rstNo}`}
+          loading={isLoading}
+          pagination={{
+            current: searchParams.page + 1,
+            pageSize: searchParams.size,
+            total: data?.data?.totalElements || 0,
+            showSizeChanger: true,
+            showTotal: (total) => `총 ${total}건`,
+            onChange: (page, pageSize) => {
+              setSearchParams((prev) => ({ ...prev, page: page - 1, size: pageSize }));
+            },
+          }}
+          size="small"
+          scroll={{ x: 1000 }}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/web-admin/src/pages/gosi/GosiStatistics.tsx
+++ b/web-admin/src/pages/gosi/GosiStatistics.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Table, Card, Select, Row, Col, Button, Space, Statistic } from 'antd';
+import { SearchOutlined, ReloadOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { gosiApi } from '../../api/gosiApi';
+import type { GosiStatMstResponse } from '../../types/gosi';
+
+export default function GosiStatistics() {
+  const [searchParams, setSearchParams] = useState({
+    gosiCd: '',
+    gosiType: '',
+    page: 0,
+    size: 20,
+  });
+
+  // 시험 목록
+  const { data: examData } = useQuery({
+    queryKey: ['gosi-exams'],
+    queryFn: () => gosiApi.getExamList(),
+  });
+
+  // 유형 목록
+  const { data: typeData } = useQuery({
+    queryKey: ['gosi-types'],
+    queryFn: () => gosiApi.getTypeList(),
+  });
+
+  // 통계 목록 (페이징)
+  const { data, isLoading } = useQuery({
+    queryKey: ['gosi-stat', searchParams],
+    queryFn: () => gosiApi.getStatList(searchParams),
+    enabled: !!searchParams.gosiCd,
+  });
+
+  // 대시보드 (전체)
+  const { data: dashData } = useQuery({
+    queryKey: ['gosi-dashboard', searchParams.gosiCd],
+    queryFn: () => gosiApi.getDashboard(searchParams.gosiCd),
+    enabled: !!searchParams.gosiCd,
+  });
+
+  const handleReset = () => {
+    setSearchParams({ gosiCd: '', gosiType: '', page: 0, size: 20 });
+  };
+
+  // 대시보드 요약
+  const dashboardStats = dashData?.data || [];
+  const totalParticipants = dashboardStats.reduce((sum, s) => sum + (s.totalCnt || 0), 0);
+  const totalPassCnt = dashboardStats.reduce((sum, s) => sum + (s.passCnt || 0), 0);
+  const avgPassRate = dashboardStats.length > 0
+    ? (dashboardStats.reduce((sum, s) => sum + (s.passRate || 0), 0) / dashboardStats.length).toFixed(1)
+    : '0';
+
+  const columns: ColumnsType<GosiStatMstResponse> = [
+    { title: '시험유형', dataIndex: 'gosiTypeNm', key: 'gosiTypeNm', width: 120 },
+    { title: '지역', dataIndex: 'gosiAreaNm', key: 'gosiAreaNm', width: 120 },
+    { title: '과목', dataIndex: 'gosiSubjectNm', key: 'gosiSubjectNm', width: 150 },
+    {
+      title: '응시자수', dataIndex: 'totalCnt', key: 'totalCnt', width: 90, align: 'center',
+      render: (v) => v != null ? `${v}명` : '-',
+    },
+    {
+      title: '평균점수', dataIndex: 'avgScore', key: 'avgScore', width: 90, align: 'center',
+      render: (v) => v != null ? `${v}` : '-',
+    },
+    {
+      title: '최고점', dataIndex: 'maxScore', key: 'maxScore', width: 80, align: 'center',
+      render: (v) => v != null ? `${v}` : '-',
+    },
+    {
+      title: '최저점', dataIndex: 'minScore', key: 'minScore', width: 80, align: 'center',
+      render: (v) => v != null ? `${v}` : '-',
+    },
+    {
+      title: '합격자수', dataIndex: 'passCnt', key: 'passCnt', width: 90, align: 'center',
+      render: (v) => v != null ? `${v}명` : '-',
+    },
+    {
+      title: '합격률', dataIndex: 'passRate', key: 'passRate', width: 80, align: 'center',
+      render: (v) => v != null ? `${v}%` : '-',
+    },
+  ];
+
+  return (
+    <div>
+      <Card style={{ marginBottom: 16 }}>
+        <Row gutter={[16, 16]} align="middle">
+          <Col>
+            <Select
+              placeholder="시험 선택"
+              style={{ width: 200 }}
+              value={searchParams.gosiCd || undefined}
+              onChange={(v) => setSearchParams((prev) => ({ ...prev, gosiCd: v || '', page: 0 }))}
+              options={(examData?.data || []).map((e) => ({
+                value: e.gosiCd,
+                label: e.gosiNm || e.gosiCd,
+              }))}
+            />
+          </Col>
+          <Col>
+            <Select
+              placeholder="시험유형"
+              allowClear
+              style={{ width: 140 }}
+              value={searchParams.gosiType || undefined}
+              onChange={(v) => setSearchParams((prev) => ({ ...prev, gosiType: v || '', page: 0 }))}
+              options={(typeData?.data || []).map((t) => ({
+                value: t.gosiType,
+                label: t.gosiTypeNm,
+              }))}
+            />
+          </Col>
+          <Col>
+            <Space>
+              <Button icon={<SearchOutlined />} type="primary"
+                onClick={() => setSearchParams((prev) => ({ ...prev, page: 0 }))}>
+                검색
+              </Button>
+              <Button icon={<ReloadOutlined />} onClick={handleReset}>초기화</Button>
+            </Space>
+          </Col>
+        </Row>
+      </Card>
+
+      {searchParams.gosiCd && dashboardStats.length > 0 && (
+        <Row gutter={16} style={{ marginBottom: 16 }}>
+          <Col span={8}>
+            <Card>
+              <Statistic title="총 응시자" value={totalParticipants} suffix="명" />
+            </Card>
+          </Col>
+          <Col span={8}>
+            <Card>
+              <Statistic title="총 합격자" value={totalPassCnt} suffix="명" />
+            </Card>
+          </Col>
+          <Col span={8}>
+            <Card>
+              <Statistic title="평균 합격률" value={avgPassRate} suffix="%" />
+            </Card>
+          </Col>
+        </Row>
+      )}
+
+      <Card title={<span>통계 목록 (총 <strong>{data?.data?.totalElements || 0}</strong>건)</span>}>
+        <Table
+          columns={columns}
+          dataSource={data?.data?.content || []}
+          rowKey={(r) => `${r.gosiCd}-${r.gosiType}-${r.gosiArea}-${r.gosiSubjectCd}`}
+          loading={isLoading}
+          pagination={{
+            current: searchParams.page + 1,
+            pageSize: searchParams.size,
+            total: data?.data?.totalElements || 0,
+            showSizeChanger: true,
+            showTotal: (total) => `총 ${total}건`,
+            onChange: (page, pageSize) => {
+              setSearchParams((prev) => ({ ...prev, page: page - 1, size: pageSize }));
+            },
+          }}
+          size="small"
+          scroll={{ x: 1000 }}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/web-admin/src/pages/gosi/GosiSubjectList.tsx
+++ b/web-admin/src/pages/gosi/GosiSubjectList.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Table, Card, Select, Row, Col, Input, Button, Space, Tag } from 'antd';
+import { SearchOutlined, ReloadOutlined } from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import { gosiApi } from '../../api/gosiApi';
+import type { GosiSubjectResponse, GosiVodResponse } from '../../types/gosi';
+
+export default function GosiSubjectList() {
+  const [selectedType, setSelectedType] = useState<string>('');
+  const [vodParams, setVodParams] = useState({
+    gosiCd: '',
+    keyword: '',
+    page: 0,
+    size: 20,
+  });
+
+  // 유형 목록
+  const { data: typeData } = useQuery({
+    queryKey: ['gosi-types'],
+    queryFn: () => gosiApi.getTypeList(),
+  });
+
+  // 시험 목록
+  const { data: examData } = useQuery({
+    queryKey: ['gosi-exams'],
+    queryFn: () => gosiApi.getExamList(),
+  });
+
+  // 과목 목록
+  const { data: subjectData, isLoading: subjectLoading } = useQuery({
+    queryKey: ['gosi-subjects', selectedType],
+    queryFn: () => gosiApi.getSubjectList(selectedType || undefined),
+  });
+
+  // VOD 목록
+  const { data: vodData, isLoading: vodLoading } = useQuery({
+    queryKey: ['gosi-vods', vodParams],
+    queryFn: () => gosiApi.getVodList(vodParams),
+  });
+
+  const subjectColumns: ColumnsType<GosiSubjectResponse> = [
+    { title: '유형', dataIndex: 'gosiType', key: 'gosiType', width: 100 },
+    { title: '과목코드', dataIndex: 'gosiSubjectCd', key: 'gosiSubjectCd', width: 120 },
+    { title: '과목명', dataIndex: 'gosiSubjecNm', key: 'gosiSubjecNm' },
+    {
+      title: '사용', dataIndex: 'isuse', key: 'isuse', width: 70, align: 'center',
+      render: (v) => <Tag color={v === 'Y' ? 'green' : 'red'}>{v === 'Y' ? '사용' : '미사용'}</Tag>,
+    },
+    { title: '순서', dataIndex: 'pos', key: 'pos', width: 70, align: 'center' },
+  ];
+
+  const vodColumns: ColumnsType<GosiVodResponse> = [
+    { title: '시험코드', dataIndex: 'gosiCd', key: 'gosiCd', width: 100 },
+    { title: '과목', dataIndex: 'subjectNm', key: 'subjectNm', width: 120 },
+    { title: '강사', dataIndex: 'prfNm', key: 'prfNm', width: 120 },
+    { title: 'VOD명', dataIndex: 'vodNm', key: 'vodNm' },
+    {
+      title: 'URL', dataIndex: 'vodUrl', key: 'vodUrl', width: 200, ellipsis: true,
+      render: (v) => v ? <a href={v} target="_blank" rel="noopener noreferrer">{v}</a> : '-',
+    },
+    {
+      title: '사용', dataIndex: 'isuse', key: 'isuse', width: 70, align: 'center',
+      render: (v) => <Tag color={v === 'Y' ? 'green' : 'red'}>{v === 'Y' ? '사용' : '미사용'}</Tag>,
+    },
+  ];
+
+  return (
+    <div>
+      <Card
+        title={
+          <Space>
+            <span>과목 목록 ({subjectData?.data?.length || 0}건)</span>
+            <Select
+              placeholder="시험유형 필터"
+              allowClear
+              style={{ width: 160 }}
+              value={selectedType || undefined}
+              onChange={(v) => setSelectedType(v || '')}
+              options={(typeData?.data || []).map((t) => ({
+                value: t.gosiType,
+                label: t.gosiTypeNm,
+              }))}
+            />
+          </Space>
+        }
+        style={{ marginBottom: 16 }}
+      >
+        <Table
+          columns={subjectColumns}
+          dataSource={subjectData?.data || []}
+          rowKey={(r) => `${r.gosiType}-${r.gosiSubjectCd}`}
+          loading={subjectLoading}
+          pagination={false}
+          size="small"
+          scroll={{ x: 600 }}
+        />
+      </Card>
+
+      <Card title={<span>VOD 목록 (총 <strong>{vodData?.data?.totalElements || 0}</strong>건)</span>}>
+        <Row gutter={[16, 16]} align="middle" style={{ marginBottom: 16 }}>
+          <Col>
+            <Select
+              placeholder="시험 선택"
+              allowClear
+              style={{ width: 200 }}
+              value={vodParams.gosiCd || undefined}
+              onChange={(v) => setVodParams((prev) => ({ ...prev, gosiCd: v || '', page: 0 }))}
+              options={(examData?.data || []).map((e) => ({
+                value: e.gosiCd,
+                label: e.gosiNm || e.gosiCd,
+              }))}
+            />
+          </Col>
+          <Col flex="auto">
+            <Input
+              placeholder="과목명, 강사명, VOD명 검색"
+              value={vodParams.keyword}
+              onChange={(e) => setVodParams((prev) => ({ ...prev, keyword: e.target.value }))}
+              onPressEnter={() => setVodParams((prev) => ({ ...prev, page: 0 }))}
+              style={{ width: 250 }}
+            />
+          </Col>
+          <Col>
+            <Space>
+              <Button icon={<SearchOutlined />} type="primary"
+                onClick={() => setVodParams((prev) => ({ ...prev, page: 0 }))}>
+                검색
+              </Button>
+              <Button icon={<ReloadOutlined />}
+                onClick={() => setVodParams({ gosiCd: '', keyword: '', page: 0, size: 20 })}>
+                초기화
+              </Button>
+            </Space>
+          </Col>
+        </Row>
+        <Table
+          columns={vodColumns}
+          dataSource={vodData?.data?.content || []}
+          rowKey={(r) => `${r.gosiCd}-${r.prfId}-${r.idx}`}
+          loading={vodLoading}
+          pagination={{
+            current: vodParams.page + 1,
+            pageSize: vodParams.size,
+            total: vodData?.data?.totalElements || 0,
+            showSizeChanger: true,
+            showTotal: (total) => `총 ${total}건`,
+            onChange: (page, pageSize) => {
+              setVodParams((prev) => ({ ...prev, page: page - 1, size: pageSize }));
+            },
+          }}
+          size="small"
+          scroll={{ x: 800 }}
+        />
+      </Card>
+    </div>
+  );
+}

--- a/web-admin/src/types/gosi.ts
+++ b/web-admin/src/types/gosi.ts
@@ -1,0 +1,158 @@
+// 시험 마스터
+export interface GosiMstResponse {
+  gosiCd: string;
+  gosiNm: string;
+  gosiType: string;
+  startDt: string | null;
+  endDt: string | null;
+  isuse: string;
+  regDt: string | null;
+  gosiYear: string | null;
+  gosiRound: string | null;
+  totalScore: number | null;
+  passScore: number | null;
+}
+
+// 시험 유형 코드
+export interface GosiCodResponse {
+  gosiType: string;
+  gosiTypeNm: string;
+  isuse: string;
+  pos: string;
+}
+
+// 지역
+export interface GosiAreaResponse {
+  gosiType: string;
+  gosiArea: string;
+  gosiAreaNm: string;
+  isuse: string;
+  pos: string;
+}
+
+// 과목
+export interface GosiSubjectResponse {
+  gosiType: string;
+  gosiSubjectCd: string;
+  gosiSubjecNm: string;
+  isuse: string;
+  pos: string;
+}
+
+// 정답
+export interface GosiPassMstResponse {
+  gosiCd: string;
+  subjectCd: string;
+  examType: string;
+  itemNo: number;
+  answerData: string;
+  subjectNm: string;
+}
+
+// 합격선
+export interface GosiPassStaResponse {
+  gosiCd: string;
+  gosiType: string;
+  gosiTypeNm: string;
+  passScore: number | null;
+  isuse: string;
+}
+
+// 성적 마스터
+export interface GosiRstMstResponse {
+  gosiCd: string;
+  rstNo: string;
+  userId: string;
+  gosiType: string;
+  gosiArea: string;
+  totalScore: number | null;
+  avgScore: number | null;
+  passYn: string;
+  regDt: string | null;
+}
+
+// 성적 상세 (답안)
+export interface GosiRstDetResponse {
+  gosiCd: string;
+  rstNo: string;
+  subjectCd: string;
+  itemNo: number;
+  userId: string;
+  answerData: string;
+  isCorrect: string;
+  regDt: string | null;
+}
+
+// 성적 과목별
+export interface GosiRstSbjResponse {
+  gosiCd: string;
+  rstNo: string;
+  subjectCd: string;
+  subjectNm: string;
+  score: number | null;
+  correctCnt: number | null;
+  totalCnt: number | null;
+}
+
+// 성적 상세 (전체)
+export interface GosiRstDetailResponse {
+  master: GosiRstMstResponse;
+  subjects: GosiRstSbjResponse[];
+  details: GosiRstDetResponse[];
+}
+
+// 통계
+export interface GosiStatMstResponse {
+  gosiCd: string;
+  gosiType: string;
+  gosiArea: string;
+  gosiSubjectCd: string;
+  gosiTypeNm: string;
+  gosiAreaNm: string;
+  gosiSubjectNm: string;
+  totalCnt: number | null;
+  avgScore: number | null;
+  maxScore: number | null;
+  minScore: number | null;
+  passCnt: number | null;
+  passRate: number | null;
+}
+
+// 과목 구분
+export interface GosiSbjMstResponse {
+  gosiCd: string;
+  sbjType: string;
+  subjectCd: string;
+  subjectNm: string;
+  isuse: string;
+  pos: string;
+}
+
+// VOD
+export interface GosiVodResponse {
+  gosiCd: string;
+  prfId: string;
+  idx: number;
+  subjectCd: string;
+  subjectNm: string;
+  prfNm: string;
+  vodUrl: string;
+  vodNm: string;
+  isuse: string;
+}
+
+// 회원
+export interface GosiMemberResponse {
+  userId: string;
+  userNm: string;
+  userNicknm: string | null;
+  userPosition: string | null;
+  sex: string | null;
+  userRole: string | null;
+  adminRole: string | null;
+  birthDay: string | null;
+  categoryCode: string | null;
+  userPoint: number | null;
+  payment: number | null;
+  isuse: string;
+}


### PR DESCRIPTION
## Summary
- Oracle willbes_gosi 마이그레이션 데이터(14개 테이블, 222,299건)를 관리하는 백엔드 API + 프론트엔드 화면 구현
- 백엔드: Entity 13개, IdClass 10개, Repository 13개, DTO 7개, Service 6개, Controller 6개 (`com.hopenvision.admin`)
- 프론트엔드: 합격예측 서브메뉴 6개 페이지 (시험/지역, 정답, 성적, 통계, 과목/VOD, 회원)

## Changes (68 files, +3,516 lines)
- `api/src/main/java/com/hopenvision/admin/` - 백엔드 전체 (Entity/Repository/DTO/Service/Controller)
- `web-admin/src/pages/gosi/` - 프론트엔드 7개 페이지
- `web-admin/src/types/gosi.ts` + `web-admin/src/api/gosiApi.ts` - 타입/API
- `web-admin/src/App.tsx` + `AdminLayout.tsx` - 라우트 및 사이드바 메뉴 추가
- `scripts/cleanup_gosi_duplicates.sql` - 중복 데이터 정리 SQL
- `ExamService.java` - 기존 lambda 변수 컴파일 에러 수정

## Test plan
- [x] `./gradlew build` 백엔드 빌드 성공
- [x] `npm run build:admin` 프론트엔드 빌드 성공
- [ ] dev 서버에서 Swagger UI API 엔드포인트 확인
- [ ] 브라우저에서 합격예측 메뉴 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)