### PR TITLE
feat: GOSI 성적 분석 대시보드

### DIFF
--- a/api/src/main/java/com/hopenvision/admin/controller/GosiStatController.java
+++ b/api/src/main/java/com/hopenvision/admin/controller/GosiStatController.java
@@ -58,4 +58,45 @@ public class GosiStatController {
         List<GosiStatDto.SbjMstResponse> result = gosiStatService.getSbjMstList(gosiCd);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
+
+    // === 성적 분석 ===
+
+    @Operation(summary = "점수 분포 조회", description = "시험별 점수 분포를 10점 구간으로 조회합니다.")
+    @GetMapping("/analytics/score-distribution")
+    public ResponseEntity<ApiResponse<List<GosiStatDto.ScoreDistributionResponse>>> getScoreDistribution(
+            @Parameter(description = "시험코드", required = true) @RequestParam String gosiCd,
+            @Parameter(description = "시험유형") @RequestParam(required = false) String gosiType,
+            @Parameter(description = "지역") @RequestParam(required = false) String gosiArea
+    ) {
+        List<GosiStatDto.ScoreDistributionResponse> result = gosiStatService.getScoreDistribution(gosiCd, gosiType, gosiArea);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "년도별 추이 조회", description = "년도별 평균점수와 합격률 추이를 조회합니다.")
+    @GetMapping("/analytics/yearly-trend")
+    public ResponseEntity<ApiResponse<List<GosiStatDto.YearlyTrendResponse>>> getYearlyTrend(
+            @Parameter(description = "시험유형") @RequestParam(required = false) String gosiType
+    ) {
+        List<GosiStatDto.YearlyTrendResponse> result = gosiStatService.getYearlyTrend(gosiType);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "과목별 성적 비교", description = "시험별 과목별 평균/최고/최저 점수를 비교합니다.")
+    @GetMapping("/analytics/subject-comparison")
+    public ResponseEntity<ApiResponse<List<GosiStatDto.SubjectScoreResponse>>> getSubjectComparison(
+            @Parameter(description = "시험코드", required = true) @RequestParam String gosiCd
+    ) {
+        List<GosiStatDto.SubjectScoreResponse> result = gosiStatService.getSubjectScoreComparison(gosiCd);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @Operation(summary = "지역별 성적 비교", description = "시험별 지역별 평균점수와 합격률을 비교합니다.")
+    @GetMapping("/analytics/area-comparison")
+    public ResponseEntity<ApiResponse<List<GosiStatDto.AreaScoreResponse>>> getAreaComparison(
+            @Parameter(description = "시험코드", required = true) @RequestParam String gosiCd,
+            @Parameter(description = "시험유형") @RequestParam(required = false) String gosiType
+    ) {
+        List<GosiStatDto.AreaScoreResponse> result = gosiStatService.getAreaScoreComparison(gosiCd, gosiType);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
 }

--- a/api/src/main/java/com/hopenvision/admin/dto/GosiStatDto.java
+++ b/api/src/main/java/com/hopenvision/admin/dto/GosiStatDto.java
@@ -52,4 +52,53 @@ public class GosiStatDto {
         private int page = 0;
         private int size = 20;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ScoreDistributionResponse {
+        private String range;
+        private Long count;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class YearlyTrendResponse {
+        private String gosiYear;
+        private BigDecimal avgScore;
+        private BigDecimal passRate;
+        private Long totalCnt;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SubjectScoreResponse {
+        private String subjectCd;
+        private String subjectNm;
+        private BigDecimal avgScore;
+        private BigDecimal maxScore;
+        private BigDecimal minScore;
+        private Long totalCnt;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AreaScoreResponse {
+        private String gosiArea;
+        private String gosiAreaNm;
+        private BigDecimal avgScore;
+        private BigDecimal passRate;
+        private Integer totalCnt;
+    }
 }

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiRstMstRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiRstMstRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface GosiRstMstRepository extends JpaRepository<GosiRstMst, GosiRstMstId> {
 
@@ -23,4 +25,35 @@ public interface GosiRstMstRepository extends JpaRepository<GosiRstMst, GosiRstM
             @Param("gosiArea") String gosiArea,
             @Param("keyword") String keyword,
             Pageable pageable);
+
+    @Query(value = "SELECT " +
+            "CASE WHEN FLOOR(total_score / 10) >= 10 THEN '90~100' " +
+            "     ELSE CONCAT(CAST(FLOOR(total_score / 10) * 10 AS INTEGER), '~', CAST(FLOOR(total_score / 10) * 10 + 9 AS INTEGER)) " +
+            "END AS range, " +
+            "COUNT(*) AS count " +
+            "FROM gosi_rst_mst " +
+            "WHERE gosi_cd = :gosiCd " +
+            "AND (:gosiType IS NULL OR :gosiType = '' OR gosi_type = :gosiType) " +
+            "AND (:gosiArea IS NULL OR :gosiArea = '' OR gosi_area = :gosiArea) " +
+            "GROUP BY CASE WHEN FLOOR(total_score / 10) >= 10 THEN '90~100' " +
+            "     ELSE CONCAT(CAST(FLOOR(total_score / 10) * 10 AS INTEGER), '~', CAST(FLOOR(total_score / 10) * 10 + 9 AS INTEGER)) " +
+            "END " +
+            "ORDER BY MIN(total_score)", nativeQuery = true)
+    List<Object[]> findScoreDistribution(
+            @Param("gosiCd") String gosiCd,
+            @Param("gosiType") String gosiType,
+            @Param("gosiArea") String gosiArea);
+
+    @Query(value = "SELECT m.gosi_year, " +
+            "AVG(r.total_score) AS avg_score, " +
+            "CASE WHEN COUNT(*) > 0 THEN " +
+            "  CAST(SUM(CASE WHEN r.pass_yn = 'Y' THEN 1 ELSE 0 END) AS DECIMAL) * 100.0 / COUNT(*) " +
+            "ELSE 0 END AS pass_rate, " +
+            "COUNT(*) AS total_cnt " +
+            "FROM gosi_rst_mst r " +
+            "JOIN gosi_mst m ON r.gosi_cd = m.gosi_cd " +
+            "WHERE (:gosiType IS NULL OR :gosiType = '' OR r.gosi_type = :gosiType) " +
+            "GROUP BY m.gosi_year " +
+            "ORDER BY m.gosi_year", nativeQuery = true)
+    List<Object[]> findYearlyTrend(@Param("gosiType") String gosiType);
 }

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiRstSbjRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiRstSbjRepository.java
@@ -3,6 +3,8 @@ package com.hopenvision.admin.repository;
 import com.hopenvision.admin.entity.GosiRstSbj;
 import com.hopenvision.admin.entity.GosiRstSbjId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +13,10 @@ import java.util.List;
 public interface GosiRstSbjRepository extends JpaRepository<GosiRstSbj, GosiRstSbjId> {
 
     List<GosiRstSbj> findByGosiCdAndRstNoOrderBySubjectCd(String gosiCd, String rstNo);
+
+    @Query("SELECT s.subjectCd, s.subjectNm, AVG(s.score), MAX(s.score), MIN(s.score), COUNT(s) " +
+           "FROM GosiRstSbj s WHERE s.gosiCd = :gosiCd " +
+           "GROUP BY s.subjectCd, s.subjectNm " +
+           "ORDER BY s.subjectCd")
+    List<Object[]> findSubjectScoreComparison(@Param("gosiCd") String gosiCd);
 }

--- a/api/src/main/java/com/hopenvision/admin/repository/GosiStatMstRepository.java
+++ b/api/src/main/java/com/hopenvision/admin/repository/GosiStatMstRepository.java
@@ -23,4 +23,14 @@ public interface GosiStatMstRepository extends JpaRepository<GosiStatMst, GosiSt
             Pageable pageable);
 
     List<GosiStatMst> findByGosiCdOrderByGosiTypeAscGosiAreaAsc(String gosiCd);
+
+    @Query("SELECT s.gosiArea, s.gosiAreaNm, AVG(s.avgScore), AVG(s.passRate), SUM(s.totalCnt) " +
+           "FROM GosiStatMst s WHERE s.gosiCd = :gosiCd " +
+           "AND s.gosiSubjectCd = 'ALL' " +
+           "AND (:gosiType IS NULL OR :gosiType = '' OR s.gosiType = :gosiType) " +
+           "GROUP BY s.gosiArea, s.gosiAreaNm " +
+           "ORDER BY s.gosiArea")
+    List<Object[]> findAreaScoreComparison(
+            @Param("gosiCd") String gosiCd,
+            @Param("gosiType") String gosiType);
 }

--- a/api/src/main/java/com/hopenvision/admin/service/GosiStatService.java
+++ b/api/src/main/java/com/hopenvision/admin/service/GosiStatService.java
@@ -3,6 +3,8 @@ package com.hopenvision.admin.service;
 import com.hopenvision.admin.dto.GosiStatDto;
 import com.hopenvision.admin.entity.GosiSbjMst;
 import com.hopenvision.admin.entity.GosiStatMst;
+import com.hopenvision.admin.repository.GosiRstMstRepository;
+import com.hopenvision.admin.repository.GosiRstSbjRepository;
 import com.hopenvision.admin.repository.GosiSbjMstRepository;
 import com.hopenvision.admin.repository.GosiStatMstRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,6 +28,8 @@ public class GosiStatService {
 
     private final GosiStatMstRepository gosiStatMstRepository;
     private final GosiSbjMstRepository gosiSbjMstRepository;
+    private final GosiRstMstRepository gosiRstMstRepository;
+    private final GosiRstSbjRepository gosiRstSbjRepository;
 
     /**
      * 통계 목록 조회 (페이징)
@@ -71,6 +77,69 @@ public class GosiStatService {
                 .passCnt(entity.getPassCnt())
                 .passRate(entity.getPassRate())
                 .build();
+    }
+
+    /**
+     * 점수 분포 조회
+     */
+    public List<GosiStatDto.ScoreDistributionResponse> getScoreDistribution(String gosiCd, String gosiType, String gosiArea) {
+        return gosiRstMstRepository.findScoreDistribution(gosiCd, gosiType, gosiArea).stream()
+                .map(row -> GosiStatDto.ScoreDistributionResponse.builder()
+                        .range((String) row[0])
+                        .count(((Number) row[1]).longValue())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 년도별 추이 조회
+     */
+    public List<GosiStatDto.YearlyTrendResponse> getYearlyTrend(String gosiType) {
+        return gosiRstMstRepository.findYearlyTrend(gosiType).stream()
+                .map(row -> GosiStatDto.YearlyTrendResponse.builder()
+                        .gosiYear((String) row[0])
+                        .avgScore(toBigDecimal(row[1]))
+                        .passRate(toBigDecimal(row[2]))
+                        .totalCnt(((Number) row[3]).longValue())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 과목별 성적 비교
+     */
+    public List<GosiStatDto.SubjectScoreResponse> getSubjectScoreComparison(String gosiCd) {
+        return gosiRstSbjRepository.findSubjectScoreComparison(gosiCd).stream()
+                .map(row -> GosiStatDto.SubjectScoreResponse.builder()
+                        .subjectCd((String) row[0])
+                        .subjectNm((String) row[1])
+                        .avgScore(toBigDecimal(row[2]))
+                        .maxScore(toBigDecimal(row[3]))
+                        .minScore(toBigDecimal(row[4]))
+                        .totalCnt(((Number) row[5]).longValue())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 지역별 성적 비교
+     */
+    public List<GosiStatDto.AreaScoreResponse> getAreaScoreComparison(String gosiCd, String gosiType) {
+        return gosiStatMstRepository.findAreaScoreComparison(gosiCd, gosiType).stream()
+                .map(row -> GosiStatDto.AreaScoreResponse.builder()
+                        .gosiArea((String) row[0])
+                        .gosiAreaNm((String) row[1])
+                        .avgScore(toBigDecimal(row[2]))
+                        .passRate(toBigDecimal(row[3]))
+                        .totalCnt(((Number) row[4]).intValue())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    private BigDecimal toBigDecimal(Object value) {
+        if (value == null) return BigDecimal.ZERO;
+        if (value instanceof BigDecimal) return ((BigDecimal) value).setScale(2, RoundingMode.HALF_UP);
+        return BigDecimal.valueOf(((Number) value).doubleValue()).setScale(2, RoundingMode.HALF_UP);
     }
 
     private GosiStatDto.SbjMstResponse toSbjMstResponse(GosiSbjMst entity) {

--- a/web-admin/src/App.tsx
+++ b/web-admin/src/App.tsx
@@ -18,6 +18,7 @@ import GosiPassList from './pages/gosi/GosiPassList';
 import GosiScoreList from './pages/gosi/GosiScoreList';
 import GosiScoreDetail from './pages/gosi/GosiScoreDetail';
 import GosiStatistics from './pages/gosi/GosiStatistics';
+import GosiAnalytics from './pages/gosi/GosiAnalytics';
 import GosiSubjectList from './pages/gosi/GosiSubjectList';
 import GosiMemberList from './pages/gosi/GosiMemberList';
 import './App.css';
@@ -59,6 +60,7 @@ function App() {
                 <Route path="gosi/results" element={<GosiScoreList />} />
                 <Route path="gosi/results/:gosiCd/:rstNo" element={<GosiScoreDetail />} />
                 <Route path="gosi/statistics" element={<GosiStatistics />} />
+                <Route path="gosi/analytics" element={<GosiAnalytics />} />
                 <Route path="gosi/subjects" element={<GosiSubjectList />} />
                 <Route path="gosi/members" element={<GosiMemberList />} />
                 <Route path="*" element={<Navigate to="/exams" replace />} />

--- a/web-admin/src/api/gosiApi.ts
+++ b/web-admin/src/api/gosiApi.ts
@@ -13,6 +13,10 @@ import type {
   GosiSbjMstResponse,
   GosiVodResponse,
   GosiMemberResponse,
+  GosiScoreDistribution,
+  GosiYearlyTrend,
+  GosiSubjectScore,
+  GosiAreaScore,
 } from '../types/gosi';
 
 export const gosiApi = {
@@ -90,6 +94,34 @@ export const gosiApi = {
 
   getSbjMstList: async (gosiCd: string): Promise<ApiResponse<GosiSbjMstResponse[]>> => {
     const response = await client.get('/api/gosi/statistics/subjects', { params: { gosiCd } });
+    return response.data;
+  },
+
+  // === 성적 분석 ===
+  getScoreDistribution: async (params: {
+    gosiCd: string;
+    gosiType?: string;
+    gosiArea?: string;
+  }): Promise<ApiResponse<GosiScoreDistribution[]>> => {
+    const response = await client.get('/api/gosi/statistics/analytics/score-distribution', { params });
+    return response.data;
+  },
+
+  getYearlyTrend: async (gosiType?: string): Promise<ApiResponse<GosiYearlyTrend[]>> => {
+    const response = await client.get('/api/gosi/statistics/analytics/yearly-trend', { params: { gosiType } });
+    return response.data;
+  },
+
+  getSubjectComparison: async (gosiCd: string): Promise<ApiResponse<GosiSubjectScore[]>> => {
+    const response = await client.get('/api/gosi/statistics/analytics/subject-comparison', { params: { gosiCd } });
+    return response.data;
+  },
+
+  getAreaComparison: async (params: {
+    gosiCd: string;
+    gosiType?: string;
+  }): Promise<ApiResponse<GosiAreaScore[]>> => {
+    const response = await client.get('/api/gosi/statistics/analytics/area-comparison', { params });
     return response.data;
   },
 

--- a/web-admin/src/components/AdminLayout.tsx
+++ b/web-admin/src/components/AdminLayout.tsx
@@ -37,6 +37,7 @@ const menuItems = [
       { key: '/gosi/pass', label: '정답 관리' },
       { key: '/gosi/results', label: '성적 관리' },
       { key: '/gosi/statistics', label: '통계' },
+      { key: '/gosi/analytics', label: '성적 분석' },
       { key: '/gosi/subjects', label: '과목/VOD' },
       { key: '/gosi/members', label: '회원 관리' },
     ],
@@ -60,6 +61,7 @@ export default function AdminLayout() {
     if (path.startsWith('/gosi/pass')) return '/gosi/pass';
     if (path.startsWith('/gosi/results')) return '/gosi/results';
     if (path.startsWith('/gosi/statistics')) return '/gosi/statistics';
+    if (path.startsWith('/gosi/analytics')) return '/gosi/analytics';
     if (path.startsWith('/gosi/subjects')) return '/gosi/subjects';
     if (path.startsWith('/gosi/members')) return '/gosi/members';
     if (path.startsWith('/exams')) return '/exams';

--- a/web-admin/src/pages/gosi/GosiAnalytics.tsx
+++ b/web-admin/src/pages/gosi/GosiAnalytics.tsx
@@ -1,0 +1,274 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Card, Select, Row, Col, Empty, Spin, Space, Button } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { gosiApi } from '../../api/gosiApi';
+
+const CHART_COLORS = ['#1890ff', '#52c41a', '#faad14', '#f5222d', '#722ed1', '#13c2c2', '#eb2f96', '#fa8c16'];
+
+export default function GosiAnalytics() {
+  const [selectedGosiCd, setSelectedGosiCd] = useState<string | undefined>();
+  const [selectedGosiType, setSelectedGosiType] = useState<string | undefined>();
+  const [selectedGosiArea, setSelectedGosiArea] = useState<string | undefined>();
+
+  const { data: examListData } = useQuery({
+    queryKey: ['gosi', 'exams'],
+    queryFn: () => gosiApi.getExamList(),
+  });
+
+  const { data: typeListData } = useQuery({
+    queryKey: ['gosi', 'types'],
+    queryFn: () => gosiApi.getTypeList(),
+  });
+
+  const { data: areaListData } = useQuery({
+    queryKey: ['gosi', 'areas', selectedGosiType],
+    queryFn: () => gosiApi.getAreaList(selectedGosiType),
+  });
+
+  const { data: distributionData, isLoading: isDistLoading } = useQuery({
+    queryKey: ['gosi', 'analytics', 'distribution', selectedGosiCd, selectedGosiType, selectedGosiArea],
+    queryFn: () => gosiApi.getScoreDistribution({
+      gosiCd: selectedGosiCd!,
+      gosiType: selectedGosiType,
+      gosiArea: selectedGosiArea,
+    }),
+    enabled: !!selectedGosiCd,
+  });
+
+  const { data: trendData, isLoading: isTrendLoading } = useQuery({
+    queryKey: ['gosi', 'analytics', 'trend', selectedGosiType],
+    queryFn: () => gosiApi.getYearlyTrend(selectedGosiType),
+  });
+
+  const { data: subjectData, isLoading: isSubjectLoading } = useQuery({
+    queryKey: ['gosi', 'analytics', 'subject', selectedGosiCd],
+    queryFn: () => gosiApi.getSubjectComparison(selectedGosiCd!),
+    enabled: !!selectedGosiCd,
+  });
+
+  const { data: areaData, isLoading: isAreaLoading } = useQuery({
+    queryKey: ['gosi', 'analytics', 'area', selectedGosiCd, selectedGosiType],
+    queryFn: () => gosiApi.getAreaComparison({
+      gosiCd: selectedGosiCd!,
+      gosiType: selectedGosiType,
+    }),
+    enabled: !!selectedGosiCd,
+  });
+
+  const examList = examListData?.data || [];
+  const typeList = typeListData?.data || [];
+  const areaList = areaListData?.data || [];
+
+  const distribution = distributionData?.data || [];
+  const trend = trendData?.data || [];
+  const subjects = subjectData?.data || [];
+  const areas = areaData?.data || [];
+
+  const handleReset = () => {
+    setSelectedGosiCd(undefined);
+    setSelectedGosiType(undefined);
+    setSelectedGosiArea(undefined);
+  };
+
+  const distributionChartData = distribution.map((d) => ({
+    구간: d.range + '점',
+    인원수: d.count,
+  }));
+
+  const trendChartData = trend.map((t) => ({
+    년도: t.gosiYear + '년',
+    평균점수: t.avgScore,
+    합격률: t.passRate,
+    응시자수: t.totalCnt,
+  }));
+
+  const subjectChartData = subjects.map((s) => ({
+    과목: s.subjectNm,
+    평균: s.avgScore,
+    최고: s.maxScore,
+    최저: s.minScore,
+  }));
+
+  const areaChartData = areas.map((a) => ({
+    지역: a.gosiAreaNm || a.gosiArea,
+    평균점수: a.avgScore,
+    합격률: a.passRate,
+    응시자수: a.totalCnt,
+  }));
+
+  return (
+    <div>
+      <Card style={{ marginBottom: 16 }}>
+        <Space wrap>
+          <span style={{ fontWeight: 'bold' }}>필터:</span>
+          <Select
+            placeholder="시험 선택"
+            style={{ width: 280 }}
+            value={selectedGosiCd}
+            onChange={setSelectedGosiCd}
+            allowClear
+            showSearch
+            filterOption={(input, option) =>
+              (option?.label as string)?.toLowerCase().includes(input.toLowerCase()) ?? false
+            }
+            options={examList.map((exam) => ({
+              value: exam.gosiCd,
+              label: `${exam.gosiNm} (${exam.gosiCd})`,
+            }))}
+          />
+          <Select
+            placeholder="시험유형"
+            style={{ width: 160 }}
+            value={selectedGosiType}
+            onChange={(value) => {
+              setSelectedGosiType(value);
+              setSelectedGosiArea(undefined);
+            }}
+            allowClear
+            options={typeList.map((t) => ({
+              value: t.gosiType,
+              label: t.gosiTypeNm,
+            }))}
+          />
+          <Select
+            placeholder="지역"
+            style={{ width: 160 }}
+            value={selectedGosiArea}
+            onChange={setSelectedGosiArea}
+            allowClear
+            options={areaList.map((a) => ({
+              value: a.gosiArea,
+              label: a.gosiAreaNm,
+            }))}
+          />
+          <Button icon={<ReloadOutlined />} onClick={handleReset}>
+            초기화
+          </Button>
+        </Space>
+      </Card>
+
+      <Row gutter={16} style={{ marginBottom: 16 }}>
+        <Col span={12}>
+          <Card title="점수 분포도">
+            {isDistLoading ? (
+              <div style={{ textAlign: 'center', padding: 60 }}><Spin /></div>
+            ) : !selectedGosiCd ? (
+              <Empty description="시험을 선택해주세요" style={{ padding: 40 }} />
+            ) : distributionChartData.length === 0 ? (
+              <Empty description="데이터가 없습니다" style={{ padding: 40 }} />
+            ) : (
+              <ResponsiveContainer width="100%" height={300}>
+                <BarChart data={distributionChartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="구간" />
+                  <YAxis allowDecimals={false} />
+                  <Tooltip formatter={(value) => [`${value}명`, '인원수']} />
+                  <Legend />
+                  <Bar dataKey="인원수" fill={CHART_COLORS[0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </Card>
+        </Col>
+        <Col span={12}>
+          <Card title="년도별 추이">
+            {isTrendLoading ? (
+              <div style={{ textAlign: 'center', padding: 60 }}><Spin /></div>
+            ) : trendChartData.length === 0 ? (
+              <Empty description="데이터가 없습니다" style={{ padding: 40 }} />
+            ) : (
+              <ResponsiveContainer width="100%" height={300}>
+                <LineChart data={trendChartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="년도" />
+                  <YAxis yAxisId="left" domain={[0, 100]} />
+                  <YAxis yAxisId="right" orientation="right" domain={[0, 100]} />
+                  <Tooltip
+                    formatter={(value, name) => {
+                      const v = Number(value ?? 0);
+                      if (name === '합격률') return [`${v.toFixed(2)}%`, name];
+                      return [`${v.toFixed(2)}점`, name];
+                    }}
+                  />
+                  <Legend />
+                  <Line yAxisId="left" type="monotone" dataKey="평균점수" stroke={CHART_COLORS[0]} strokeWidth={2} />
+                  <Line yAxisId="right" type="monotone" dataKey="합격률" stroke={CHART_COLORS[1]} strokeWidth={2} />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
+          </Card>
+        </Col>
+      </Row>
+
+      <Row gutter={16}>
+        <Col span={12}>
+          <Card title="과목별 성적 비교">
+            {isSubjectLoading ? (
+              <div style={{ textAlign: 'center', padding: 60 }}><Spin /></div>
+            ) : !selectedGosiCd ? (
+              <Empty description="시험을 선택해주세요" style={{ padding: 40 }} />
+            ) : subjectChartData.length === 0 ? (
+              <Empty description="데이터가 없습니다" style={{ padding: 40 }} />
+            ) : (
+              <ResponsiveContainer width="100%" height={300}>
+                <BarChart data={subjectChartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="과목" />
+                  <YAxis />
+                  <Tooltip formatter={(value) => [`${value}점`]} />
+                  <Legend />
+                  <Bar dataKey="평균" fill={CHART_COLORS[0]} />
+                  <Bar dataKey="최고" fill={CHART_COLORS[1]} />
+                  <Bar dataKey="최저" fill={CHART_COLORS[3]} />
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </Card>
+        </Col>
+        <Col span={12}>
+          <Card title="지역별 성적 비교">
+            {isAreaLoading ? (
+              <div style={{ textAlign: 'center', padding: 60 }}><Spin /></div>
+            ) : !selectedGosiCd ? (
+              <Empty description="시험을 선택해주세요" style={{ padding: 40 }} />
+            ) : areaChartData.length === 0 ? (
+              <Empty description="데이터가 없습니다" style={{ padding: 40 }} />
+            ) : (
+              <ResponsiveContainer width="100%" height={300}>
+                <BarChart data={areaChartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="지역" />
+                  <YAxis yAxisId="left" />
+                  <YAxis yAxisId="right" orientation="right" domain={[0, 100]} />
+                  <Tooltip
+                    formatter={(value, name) => {
+                      const v = Number(value ?? 0);
+                      if (name === '합격률') return [`${v.toFixed(2)}%`, name];
+                      return [`${v.toFixed(2)}점`, name];
+                    }}
+                  />
+                  <Legend />
+                  <Bar yAxisId="left" dataKey="평균점수" fill={CHART_COLORS[0]} />
+                  <Bar yAxisId="right" dataKey="합격률" fill={CHART_COLORS[1]} />
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </Card>
+        </Col>
+      </Row>
+    </div>
+  );
+}

--- a/web-admin/src/types/gosi.ts
+++ b/web-admin/src/types/gosi.ts
@@ -141,6 +141,39 @@ export interface GosiVodResponse {
   isuse: string;
 }
 
+// 분석 - 점수 분포
+export interface GosiScoreDistribution {
+  range: string;
+  count: number;
+}
+
+// 분석 - 년도별 추이
+export interface GosiYearlyTrend {
+  gosiYear: string;
+  avgScore: number;
+  passRate: number;
+  totalCnt: number;
+}
+
+// 분석 - 과목별 성적
+export interface GosiSubjectScore {
+  subjectCd: string;
+  subjectNm: string;
+  avgScore: number;
+  maxScore: number;
+  minScore: number;
+  totalCnt: number;
+}
+
+// 분석 - 지역별 성적
+export interface GosiAreaScore {
+  gosiArea: string;
+  gosiAreaNm: string;
+  avgScore: number;
+  passRate: number;
+  totalCnt: number;
+}
+
 // 회원
 export interface GosiMemberResponse {
   userId: string;


### PR DESCRIPTION
## Summary
- 백엔드: 점수분포/년도별추이/과목별비교/지역별비교 4개 analytics API 엔드포인트 추가
- 프론트엔드: GosiAnalytics 대시보드 페이지 (BarChart, LineChart, 듀얼Y축 차트)
- 필터링: 시험/유형/지역 선택 가능, 년도별 추이는 전체 조회 지원

## Test plan
- [ ] 백엔드 빌드 성공 확인 (`gradlew build`)
- [ ] 프론트엔드 빌드 성공 확인 (`npm run build:admin`)
- [ ] `/gosi/analytics` 페이지 접속 및 차트 렌더링 확인
- [ ] 시험 선택 후 4개 차트 데이터 로딩 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)