### PR TITLE
docs(intro): 서비스 소개 페이지 추가 (unmong-main 게이트웨이 → 서비스 자체 호스팅)

### DIFF
--- a/web-user/public/css/service-landing.css
+++ b/web-user/public/css/service-landing.css
@@ -1,0 +1,553 @@
+:root {
+    --bg-color: #0f172a;
+    --card-bg: rgba(30, 41, 59, 0.85);
+    --card-bg-hover: rgba(30, 41, 59, 0.95);
+    --text-color: #e2e8f0;
+    --text-muted: #94a3b8;
+    --text-dim: #64748b;
+    --accent-color: #3b82f6;
+    --border-color: rgba(148, 163, 184, 0.15);
+    --service-color: #3b82f6;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--bg-color);
+    color: var(--text-color);
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background-image:
+        linear-gradient(rgba(148, 163, 184, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(148, 163, 184, 0.03) 1px, transparent 1px);
+    background-size: 40px 40px;
+    pointer-events: none;
+}
+
+body::after {
+    content: '';
+    position: fixed;
+    inset: -50%;
+    width: 200%;
+    height: 200%;
+    background:
+        radial-gradient(ellipse at 30% 10%, rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.08) 0%, transparent 50%),
+        radial-gradient(ellipse at 70% 90%, rgba(139, 92, 246, 0.05) 0%, transparent 50%);
+    pointer-events: none;
+}
+
+.sl-container {
+    position: relative;
+    z-index: 1;
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2rem 2rem 3rem;
+}
+
+/* ── Navigation ── */
+.sl-topnav {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    margin-bottom: 2rem;
+    animation: fadeInDown 0.6s ease-out;
+}
+
+.sl-nav-links {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.sl-nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.8rem;
+    font-weight: 500;
+    padding: 0.35rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    transition: all 0.2s;
+}
+
+.sl-nav-link:hover {
+    color: #fff;
+    border-color: var(--service-color);
+    background: rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.1);
+}
+
+.sl-nav-arrow {
+    font-weight: 400;
+    opacity: 0.7;
+}
+
+/* ── Hero ── */
+.sl-hero {
+    text-align: center;
+    padding: 2.5rem 1.5rem;
+    margin-bottom: 2rem;
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    background: var(--card-bg);
+    position: relative;
+    overflow: hidden;
+    animation: fadeInUp 0.7s ease-out 0.1s backwards;
+}
+
+.sl-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, var(--service-color), transparent);
+}
+
+.sl-hero-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.2rem 0.65rem;
+    border-radius: 9999px;
+    margin-bottom: 1rem;
+    color: #22c55e;
+    background: rgba(34, 197, 94, 0.1);
+}
+
+.sl-hero-status .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #22c55e;
+    animation: pulse 2s ease-in-out infinite;
+}
+
+.sl-hero h1 {
+    font-size: 2.2rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    margin-bottom: 0.3rem;
+    color: #f1f5f9;
+}
+
+.sl-hero .tagline {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    font-weight: 300;
+    margin-bottom: 0.4rem;
+}
+
+.sl-hero .desc {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    max-width: 560px;
+    margin: 0 auto 1.5rem;
+    line-height: 1.6;
+}
+
+.sl-hero-actions {
+    display: flex;
+    justify-content: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.sl-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.5rem 1.1rem;
+    border-radius: 8px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: all 0.2s;
+    border: 1px solid transparent;
+}
+
+.sl-btn-primary {
+    background: var(--service-color);
+    color: #fff;
+}
+
+.sl-btn-primary:hover {
+    filter: brightness(1.15);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.3);
+}
+
+.sl-btn-outline {
+    border-color: var(--border-color);
+    color: var(--text-muted);
+    background: transparent;
+}
+
+.sl-btn-outline:hover {
+    border-color: var(--service-color);
+    color: #fff;
+    background: rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.08);
+}
+
+/* ── Section titles ── */
+.sl-section {
+    margin-bottom: 1.75rem;
+}
+
+.sl-section-title {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--service-color);
+    margin-bottom: 0.85rem;
+    padding-left: 0.6rem;
+    border-left: 2px solid var(--service-color);
+}
+
+/* ── Features Grid ── */
+.sl-features {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.85rem;
+    animation: fadeInUp 0.7s ease-out 0.2s backwards;
+}
+
+.sl-feature {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1rem;
+    transition: all 0.25s;
+    text-decoration: none;
+    display: block;
+    cursor: pointer;
+}
+
+.sl-feature:hover {
+    background: var(--card-bg-hover);
+    border-color: rgba(148, 163, 184, 0.25);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px -6px rgba(0, 0, 0, 0.3);
+}
+
+.sl-feature-icon {
+    font-size: 1.4rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.sl-feature-name {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin-bottom: 0.25rem;
+}
+
+.sl-feature-desc {
+    font-size: 0.7rem;
+    color: var(--text-dim);
+    line-height: 1.4;
+}
+
+.sl-feature-tag {
+    display: inline-block;
+    margin-top: 0.5rem;
+    font-size: 0.6rem;
+    font-weight: 600;
+    padding: 0.15rem 0.45rem;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.1);
+    color: var(--service-color);
+}
+
+/* ── Architecture Diagram ── */
+.sl-arch {
+    animation: fadeInUp 0.7s ease-out 0.3s backwards;
+}
+
+.sl-arch-diagram {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    flex-wrap: wrap;
+}
+
+.sl-arch-node {
+    text-align: center;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: rgba(15, 23, 42, 0.6);
+    min-width: 100px;
+}
+
+.sl-arch-node-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin-bottom: 0.2rem;
+}
+
+.sl-arch-node-tech {
+    font-size: 0.6rem;
+    color: var(--text-dim);
+}
+
+.sl-arch-node.highlight {
+    border-color: var(--service-color);
+    box-shadow: 0 0 12px rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.15);
+}
+
+.sl-arch-arrow {
+    padding: 0 0.6rem;
+    color: var(--text-dim);
+    font-size: 1rem;
+}
+
+/* ── Flow Diagram ── */
+.sl-flow {
+    animation: fadeInUp 0.7s ease-out 0.35s backwards;
+}
+
+.sl-flow-steps {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0;
+    overflow-x: auto;
+}
+
+.sl-flow-step {
+    text-align: center;
+    flex-shrink: 0;
+    padding: 0.6rem 0.8rem;
+}
+
+.sl-flow-step-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.15);
+    color: var(--service-color);
+    font-size: 0.65rem;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+}
+
+.sl-flow-step-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #f1f5f9;
+    margin-bottom: 0.15rem;
+    white-space: nowrap;
+}
+
+.sl-flow-step-desc {
+    font-size: 0.6rem;
+    color: var(--text-dim);
+    white-space: nowrap;
+}
+
+.sl-flow-arrow {
+    flex-shrink: 0;
+    color: var(--text-dim);
+    font-size: 0.85rem;
+    padding: 0 0.3rem;
+    opacity: 0.5;
+}
+
+/* ── Tech Stack ── */
+.sl-tech {
+    animation: fadeInUp 0.7s ease-out 0.4s backwards;
+}
+
+.sl-tech-list {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.sl-tech-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.4rem 0.75rem;
+    border-radius: 8px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    transition: border-color 0.2s;
+}
+
+.sl-tech-badge:hover {
+    border-color: rgba(148, 163, 184, 0.3);
+}
+
+.sl-tech-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+}
+
+/* ── Connected Services ── */
+.sl-connected {
+    animation: fadeInUp 0.7s ease-out 0.45s backwards;
+}
+
+.sl-connected-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 0.7rem;
+}
+
+.sl-connected-card {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    text-decoration: none;
+    transition: all 0.2s;
+}
+
+.sl-connected-card:hover {
+    background: var(--card-bg-hover);
+    border-color: rgba(148, 163, 184, 0.25);
+    transform: translateY(-1px);
+}
+
+.sl-connected-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.sl-connected-info { flex: 1; }
+
+.sl-connected-name {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: #f1f5f9;
+}
+
+.sl-connected-role {
+    font-size: 0.62rem;
+    color: var(--text-dim);
+}
+
+.sl-connected-arrow {
+    color: var(--text-dim);
+    font-size: 0.8rem;
+    transition: color 0.2s;
+}
+
+.sl-connected-card:hover .sl-connected-arrow {
+    color: var(--service-color);
+}
+
+/* ── Footer ── */
+.sl-footer {
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border-color);
+    animation: fadeInUp 0.7s ease-out 0.5s backwards;
+}
+
+.sl-footer-inner {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.85rem 1.15rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.sl-footer-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.sl-footer-logo {
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+}
+
+.sl-footer-text {
+    font-size: 0.68rem;
+    color: var(--text-dim);
+}
+
+.sl-footer-copy {
+    font-size: 0.6rem;
+    color: var(--text-dim);
+}
+
+/* ── Animations ── */
+@keyframes fadeInDown {
+    from { opacity: 0; transform: translateY(-16px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(16px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+    .sl-container { padding: 1.5rem 1rem 2rem; }
+    .sl-hero h1 { font-size: 1.6rem; }
+    .sl-hero { padding: 1.75rem 1rem; }
+    .sl-features { grid-template-columns: repeat(2, 1fr); }
+    .sl-arch-diagram { flex-direction: column; gap: 0; }
+    .sl-arch-arrow { transform: rotate(90deg); padding: 0.3rem 0; }
+    .sl-topnav { flex-direction: column; gap: 0.5rem; align-items: flex-start; }
+}
+
+@media (max-width: 480px) {
+    .sl-features { grid-template-columns: 1fr; }
+    .sl-connected-grid { grid-template-columns: 1fr; }
+    .sl-flow-steps { padding: 1rem; }
+    .sl-hero-actions { flex-direction: column; align-items: center; }
+}

--- a/web-user/public/intro.html
+++ b/web-user/public/intro.html
@@ -10,8 +10,8 @@
     <link rel="stylesheet" href="/css/service-landing.css">
     <style>
         :root {
-            --service-color: #f59e0b;
-            --glow-r: 245; --glow-g: 158; --glow-b: 11;
+            --service-color: #3b82f6;
+            --glow-r: 59; --glow-g: 130; --glow-b: 246;
         }
     </style>
 </head>
@@ -181,7 +181,7 @@
         <section class="sl-section sl-connected">
             <div class="sl-section-title">Connected Services</div>
             <div class="sl-connected-grid">
-                <a href="https://infrawatcher.unmong.com/intro.html" class="sl-connected-card">
+                <a href="https://infrawatcher.unmong.com/intro.html" target="_blank" rel="noopener noreferrer" class="sl-connected-card">
                     <span class="sl-connected-dot" style="background:#06b6d4;"></span>
                     <div class="sl-connected-info">
                         <div class="sl-connected-name">InfraWatcher</div>
@@ -189,7 +189,7 @@
                     </div>
                     <span class="sl-connected-arrow">&#8594;</span>
                 </a>
-                <a href="https://qadashboard.unmong.com/intro.html" class="sl-connected-card">
+                <a href="https://qadashboard.unmong.com/intro.html" target="_blank" rel="noopener noreferrer" class="sl-connected-card">
                     <span class="sl-connected-dot" style="background:#8b5cf6;"></span>
                     <div class="sl-connected-info">
                         <div class="sl-connected-name">QA-Agent</div>
@@ -197,7 +197,7 @@
                     </div>
                     <span class="sl-connected-arrow">&#8594;</span>
                 </a>
-                <a href="https://standup.unmong.com/intro.html" class="sl-connected-card">
+                <a href="https://standup.unmong.com/intro.html" target="_blank" rel="noopener noreferrer" class="sl-connected-card">
                     <span class="sl-connected-dot" style="background:#14b8a6;"></span>
                     <div class="sl-connected-info">
                         <div class="sl-connected-name">StandUp</div>

--- a/web-user/public/intro.html
+++ b/web-user/public/intro.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HopenVision - Autonomous Dev & Ops</title>
+    <meta name="description" content="HopenVision - 모의고사와 입시 예측, 합격을 향한 비전">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/service-landing.css">
+    <style>
+        :root {
+            --service-color: #f59e0b;
+            --glow-r: 245; --glow-g: 158; --glow-b: 11;
+        }
+    </style>
+</head>
+<body>
+    <div class="sl-container">
+
+        <nav class="sl-topnav">
+            <div class="sl-nav-links">
+                <a href="https://www.unmong.com/index.html" class="sl-nav-link"><span class="sl-nav-arrow">&#8593;</span> Portal</a>
+                <a href="https://www.unmong.com/architecture.html" class="sl-nav-link"><span class="sl-nav-arrow">&#8594;</span> Architecture</a>
+            </div>
+        </nav>
+
+        <section class="sl-hero">
+            <div class="sl-hero-status"><span class="dot"></span> Active</div>
+            <h1>HopenVision</h1>
+            <p class="tagline">Admission Prediction System</p>
+            <p class="desc">모의고사 성적 데이터를 기반으로 대학별 합격 가능성을 예측하고, 학습 방향을 제시하는 입시 예측 시스템</p>
+            <div class="sl-hero-actions">
+                <a href="https://study.unmong.com/" target="_blank" rel="noopener" class="sl-btn sl-btn-primary">시험 채점</a>
+                <a href="https://study.unmong.com/exams" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">모의고사</a>
+                <a href="https://study.unmong.com/history" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">응시 이력</a>
+                <a href="https://admin.unmong.com/statistics" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">통계 대시보드</a>
+                <a href="https://admin.unmong.com/login" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">관리자</a>
+            </div>
+        </section>
+
+        <section class="sl-section">
+            <div class="sl-section-title">Features</div>
+            <div class="sl-features">
+                <a class="sl-feature" href="https://study.unmong.com/" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128221;</span>
+                    <div class="sl-feature-name">시험 채점</div>
+                    <div class="sl-feature-desc">OMR/약식 답안 입력 후 즉시 채점 — 과목별 점수와 합격 예측을 한 화면에 표시</div>
+                    <span class="sl-feature-tag">Public · Exam</span>
+                </a>
+                <a class="sl-feature" href="https://study.unmong.com/exams" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128203;</span>
+                    <div class="sl-feature-name">모의고사</div>
+                    <div class="sl-feature-desc">문제세트 기반 온라인 모의고사 응시 — 시간 제한·자동 채점·해설 제공</div>
+                    <span class="sl-feature-tag">Public · Mock</span>
+                </a>
+                <a class="sl-feature" href="https://study.unmong.com/history" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128202;</span>
+                    <div class="sl-feature-name">응시 이력</div>
+                    <div class="sl-feature-desc">과거 응시 결과·점수 추이·과목별 정답률을 누적 조회</div>
+                    <span class="sl-feature-tag">Public · History</span>
+                </a>
+                <a class="sl-feature" href="https://admin.unmong.com/exams" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128203;</span>
+                    <div class="sl-feature-name">시험 관리</div>
+                    <div class="sl-feature-desc">시험 회차 등록·수정·답안지 매핑·임포트 진입 통합 (관리자 전용)</div>
+                    <span class="sl-feature-tag">Admin · Exam</span>
+                </a>
+                <a class="sl-feature" href="https://admin.unmong.com/exams" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128273;</span>
+                    <div class="sl-feature-name">답안지 등록</div>
+                    <div class="sl-feature-desc">과목·문항별 정답·배점·문제유형(객관식/주관식) 일괄 입력</div>
+                    <span class="sl-feature-tag">Admin · AnswerKey</span>
+                </a>
+                <a class="sl-feature" href="https://admin.unmong.com/import/preview" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128194;</span>
+                    <div class="sl-feature-name">Excel 임포트</div>
+                    <div class="sl-feature-desc">정답표·응시자 명단 Excel 업로드 → 미리보기 → 일괄 저장 (Apache POI)</div>
+                    <span class="sl-feature-tag">Admin · Import</span>
+                </a>
+                <a class="sl-feature" href="https://admin.unmong.com/applicants" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128101;</span>
+                    <div class="sl-feature-name">응시자 관리</div>
+                    <div class="sl-feature-desc">응시자 명부·CSV 업로드·임시점수 등록·시험별 응시자 매핑 통합 운영</div>
+                    <span class="sl-feature-tag">Admin · Applicant</span>
+                </a>
+                <a class="sl-feature" href="https://admin.unmong.com/statistics" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128200;</span>
+                    <div class="sl-feature-name">통계 대시보드</div>
+                    <div class="sl-feature-desc">과목별 평균·합격률·점수 분포 시각화 (Recharts, exam_applicant 기반)</div>
+                    <span class="sl-feature-tag">Admin · Statistics</span>
+                </a>
+                <a class="sl-feature" href="https://admin.unmong.com/subjects" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128218;</span>
+                    <div class="sl-feature-name">과목 관리</div>
+                    <div class="sl-feature-desc">과목 마스터 코드·명칭·표시 순서 관리 — 시험 등록 시 참조 카탈로그</div>
+                    <span class="sl-feature-tag">Admin · Master</span>
+                </a>
+                <a class="sl-feature" href="https://admin.unmong.com/question-bank" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#127974;</span>
+                    <div class="sl-feature-name">문제은행</div>
+                    <div class="sl-feature-desc">문항 그룹·문항·정답·해설 등록 + CSV/Excel 일괄 임포트·갱신 지원</div>
+                    <span class="sl-feature-tag">Admin · QuestionBank</span>
+                </a>
+                <a class="sl-feature" href="https://admin.unmong.com/question-sets" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128196;</span>
+                    <div class="sl-feature-name">문제세트</div>
+                    <div class="sl-feature-desc">문제은행에서 문항을 골라 모의고사용 시험지 세트를 구성·발행</div>
+                    <span class="sl-feature-tag">Admin · QuestionSet</span>
+                </a>
+                <a class="sl-feature" href="https://admin.unmong.com/gosi/analytics" target="_blank" rel="noopener">
+                    <span class="sl-feature-icon">&#128269;</span>
+                    <div class="sl-feature-name">고시 분석</div>
+                    <div class="sl-feature-desc">공무원 시험 회차·과목별 정답률·난이도·오답 패턴 심층 리포트</div>
+                    <span class="sl-feature-tag">Admin · Analytics</span>
+                </a>
+            </div>
+        </section>
+
+        <section class="sl-section sl-arch">
+            <div class="sl-section-title">Architecture</div>
+            <div class="sl-arch-diagram">
+                <div class="sl-arch-node">
+                    <div class="sl-arch-node-label">Frontend</div>
+                    <div class="sl-arch-node-tech">React</div>
+                </div>
+                <div class="sl-arch-arrow">&#8594;</div>
+                <div class="sl-arch-node highlight">
+                    <div class="sl-arch-node-label">Backend</div>
+                    <div class="sl-arch-node-tech">Spring Boot</div>
+                </div>
+                <div class="sl-arch-arrow">&#8594;</div>
+                <div class="sl-arch-node">
+                    <div class="sl-arch-node-label">Database</div>
+                    <div class="sl-arch-node-tech">PostgreSQL</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sl-section sl-flow">
+            <div class="sl-section-title">Service Flow</div>
+            <div class="sl-flow-steps">
+                <div class="sl-flow-step">
+                    <div class="sl-flow-step-num">1</div>
+                    <div class="sl-flow-step-label">시험 응시</div>
+                    <div class="sl-flow-step-desc">온라인 모의고사</div>
+                </div>
+                <div class="sl-flow-arrow">&#8594;</div>
+                <div class="sl-flow-step">
+                    <div class="sl-flow-step-num">2</div>
+                    <div class="sl-flow-step-label">성적 분석</div>
+                    <div class="sl-flow-step-desc">과목별 분석</div>
+                </div>
+                <div class="sl-flow-arrow">&#8594;</div>
+                <div class="sl-flow-step">
+                    <div class="sl-flow-step-num">3</div>
+                    <div class="sl-flow-step-label">합격 예측</div>
+                    <div class="sl-flow-step-desc">대학별 가능성</div>
+                </div>
+                <div class="sl-flow-arrow">&#8594;</div>
+                <div class="sl-flow-step">
+                    <div class="sl-flow-step-num">4</div>
+                    <div class="sl-flow-step-label">통계 리포트</div>
+                    <div class="sl-flow-step-desc">추이 시각화</div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sl-section sl-tech">
+            <div class="sl-section-title">Tech Stack</div>
+            <div class="sl-tech-list">
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#61dafb;"></span> React</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#6db33f;"></span> Spring Boot</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#336791;"></span> PostgreSQL</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#2496ed;"></span> Docker</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#f97316;"></span> Nginx</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#526cfe;"></span> MkDocs</span>
+            </div>
+        </section>
+
+        <section class="sl-section sl-connected">
+            <div class="sl-section-title">Connected Services</div>
+            <div class="sl-connected-grid">
+                <a href="https://infrawatcher.unmong.com/intro.html" class="sl-connected-card">
+                    <span class="sl-connected-dot" style="background:#06b6d4;"></span>
+                    <div class="sl-connected-info">
+                        <div class="sl-connected-name">InfraWatcher</div>
+                        <div class="sl-connected-role">컨테이너 모니터링</div>
+                    </div>
+                    <span class="sl-connected-arrow">&#8594;</span>
+                </a>
+                <a href="https://qadashboard.unmong.com/intro.html" class="sl-connected-card">
+                    <span class="sl-connected-dot" style="background:#8b5cf6;"></span>
+                    <div class="sl-connected-info">
+                        <div class="sl-connected-name">QA-Agent</div>
+                        <div class="sl-connected-role">품질 자동 테스트</div>
+                    </div>
+                    <span class="sl-connected-arrow">&#8594;</span>
+                </a>
+                <a href="https://standup.unmong.com/intro.html" class="sl-connected-card">
+                    <span class="sl-connected-dot" style="background:#14b8a6;"></span>
+                    <div class="sl-connected-info">
+                        <div class="sl-connected-name">StandUp</div>
+                        <div class="sl-connected-role">업무 추적 연동</div>
+                    </div>
+                    <span class="sl-connected-arrow">&#8594;</span>
+                </a>
+            </div>
+        </section>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- unmong-main 의 `static/services/hopenvision.html` 을 서비스 자체 정적 자산으로 이전
- `web-user/public/intro.html` + `web-user/public/css/service-landing.css` 추가
- Vite 빌드 시 `dist/` 로 복사되어 nginx 가 즉시 서빙
- 접근 URL: `https://hopenvision.unmong.com/intro.html`

## Background
10개 운영 서비스 일괄 작업의 일환 — 게이트웨이가 호스팅하던 서비스 소개페이지를 각 서비스 repo 가 직접 호스팅하도록 전환. 다른 9개 서비스는 직접 push 완료, hopenvision 만 main branch protection rule 로 PR 필수.

## Changes
- `web-user/public/intro.html` (신규) — 서비스 소개 페이지
- `web-user/public/css/service-landing.css` (신규) — 공통 스타일
- 게이트웨이 / 다른 서비스 링크는 `https://{subdomain}.unmong.com/intro.html` 형식으로 통일

## Test plan
- [ ] hopenvision-web (web-user) Docker 재빌드 후 `https://hopenvision.unmong.com/intro.html` 접근 확인
- [ ] CSS / 페이지 레이아웃 정상 렌더링 확인
- [ ] Connected Services 카드 링크가 다른 서비스 도메인으로 정상 이동하는지 확인 (다른 서비스도 동일 빌드 후 작동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)