### PR TITLE
chore(intro): 시작페이지 표준 통일 (Phase A)

### DIFF
--- a/web-user/public/intro.html
+++ b/web-user/public/intro.html
@@ -28,87 +28,87 @@
         <section class="sl-hero">
             <div class="sl-hero-status"><span class="dot"></span> Active</div>
             <h1>HopenVision</h1>
-            <p class="tagline">Admission Prediction System</p>
+            <p class="tagline">Admission Prediction · 모의고사 · 합격 예측</p>
             <p class="desc">모의고사 성적 데이터를 기반으로 대학별 합격 가능성을 예측하고, 학습 방향을 제시하는 입시 예측 시스템</p>
             <div class="sl-hero-actions">
-                <a href="https://study.unmong.com/" target="_blank" rel="noopener" class="sl-btn sl-btn-primary">시험 채점</a>
-                <a href="https://study.unmong.com/exams" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">모의고사</a>
-                <a href="https://study.unmong.com/history" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">응시 이력</a>
-                <a href="https://admin.unmong.com/statistics" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">통계 대시보드</a>
-                <a href="https://admin.unmong.com/login" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">관리자</a>
+                <a href="https://hopenvision.unmong.com/" target="_blank" rel="noopener" class="sl-btn sl-btn-primary">시험 채점</a>
+                <a href="https://hopenvision.unmong.com/exams" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">모의고사</a>
+                <a href="https://hopenvision.unmong.com/history" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">응시 이력</a>
+                <a href="https://hopenvision.unmong.com/admin/statistics" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">통계 대시보드</a>
+                <a href="https://hopenvision.unmong.com/admin/login" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">관리자</a>
             </div>
         </section>
 
         <section class="sl-section">
             <div class="sl-section-title">Features</div>
             <div class="sl-features">
-                <a class="sl-feature" href="https://study.unmong.com/" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128221;</span>
                     <div class="sl-feature-name">시험 채점</div>
                     <div class="sl-feature-desc">OMR/약식 답안 입력 후 즉시 채점 — 과목별 점수와 합격 예측을 한 화면에 표시</div>
                     <span class="sl-feature-tag">Public · Exam</span>
                 </a>
-                <a class="sl-feature" href="https://study.unmong.com/exams" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/exams" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128203;</span>
                     <div class="sl-feature-name">모의고사</div>
                     <div class="sl-feature-desc">문제세트 기반 온라인 모의고사 응시 — 시간 제한·자동 채점·해설 제공</div>
                     <span class="sl-feature-tag">Public · Mock</span>
                 </a>
-                <a class="sl-feature" href="https://study.unmong.com/history" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/history" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128202;</span>
                     <div class="sl-feature-name">응시 이력</div>
                     <div class="sl-feature-desc">과거 응시 결과·점수 추이·과목별 정답률을 누적 조회</div>
                     <span class="sl-feature-tag">Public · History</span>
                 </a>
-                <a class="sl-feature" href="https://admin.unmong.com/exams" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/admin/exams" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128203;</span>
                     <div class="sl-feature-name">시험 관리</div>
                     <div class="sl-feature-desc">시험 회차 등록·수정·답안지 매핑·임포트 진입 통합 (관리자 전용)</div>
                     <span class="sl-feature-tag">Admin · Exam</span>
                 </a>
-                <a class="sl-feature" href="https://admin.unmong.com/exams" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/admin/exams" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128273;</span>
                     <div class="sl-feature-name">답안지 등록</div>
                     <div class="sl-feature-desc">과목·문항별 정답·배점·문제유형(객관식/주관식) 일괄 입력</div>
                     <span class="sl-feature-tag">Admin · AnswerKey</span>
                 </a>
-                <a class="sl-feature" href="https://admin.unmong.com/import/preview" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/admin/import/preview" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128194;</span>
                     <div class="sl-feature-name">Excel 임포트</div>
                     <div class="sl-feature-desc">정답표·응시자 명단 Excel 업로드 → 미리보기 → 일괄 저장 (Apache POI)</div>
                     <span class="sl-feature-tag">Admin · Import</span>
                 </a>
-                <a class="sl-feature" href="https://admin.unmong.com/applicants" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/admin/applicants" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128101;</span>
                     <div class="sl-feature-name">응시자 관리</div>
                     <div class="sl-feature-desc">응시자 명부·CSV 업로드·임시점수 등록·시험별 응시자 매핑 통합 운영</div>
                     <span class="sl-feature-tag">Admin · Applicant</span>
                 </a>
-                <a class="sl-feature" href="https://admin.unmong.com/statistics" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/admin/statistics" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128200;</span>
                     <div class="sl-feature-name">통계 대시보드</div>
                     <div class="sl-feature-desc">과목별 평균·합격률·점수 분포 시각화 (Recharts, exam_applicant 기반)</div>
                     <span class="sl-feature-tag">Admin · Statistics</span>
                 </a>
-                <a class="sl-feature" href="https://admin.unmong.com/subjects" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/admin/subjects" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128218;</span>
                     <div class="sl-feature-name">과목 관리</div>
                     <div class="sl-feature-desc">과목 마스터 코드·명칭·표시 순서 관리 — 시험 등록 시 참조 카탈로그</div>
                     <span class="sl-feature-tag">Admin · Master</span>
                 </a>
-                <a class="sl-feature" href="https://admin.unmong.com/question-bank" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/admin/question-bank" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#127974;</span>
                     <div class="sl-feature-name">문제은행</div>
                     <div class="sl-feature-desc">문항 그룹·문항·정답·해설 등록 + CSV/Excel 일괄 임포트·갱신 지원</div>
                     <span class="sl-feature-tag">Admin · QuestionBank</span>
                 </a>
-                <a class="sl-feature" href="https://admin.unmong.com/question-sets" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/admin/question-sets" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128196;</span>
                     <div class="sl-feature-name">문제세트</div>
                     <div class="sl-feature-desc">문제은행에서 문항을 골라 모의고사용 시험지 세트를 구성·발행</div>
                     <span class="sl-feature-tag">Admin · QuestionSet</span>
                 </a>
-                <a class="sl-feature" href="https://admin.unmong.com/gosi/analytics" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/admin/gosi/analytics" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128269;</span>
                     <div class="sl-feature-name">고시 분석</div>
                     <div class="sl-feature-desc">공무원 시험 회차·과목별 정답률·난이도·오답 패턴 심층 리포트</div>
@@ -169,12 +169,19 @@
         <section class="sl-section sl-tech">
             <div class="sl-section-title">Tech Stack</div>
             <div class="sl-tech-list">
-                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#61dafb;"></span> React</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#61dafb;"></span> React 19</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#646cff;"></span> Vite</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#0170fe;"></span> Ant Design</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#3178c6;"></span> TypeScript</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#f89820;"></span> Java 17</span>
                 <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#6db33f;"></span> Spring Boot</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#59666c;"></span> JPA · Hibernate</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#cc0000;"></span> Flyway</span>
                 <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#336791;"></span> PostgreSQL</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#dc382d;"></span> Redis</span>
+                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#1d6f42;"></span> Apache POI</span>
                 <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#2496ed;"></span> Docker</span>
                 <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#f97316;"></span> Nginx</span>
-                <span class="sl-tech-badge"><span class="sl-tech-dot" style="background:#526cfe;"></span> MkDocs</span>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary

Phase A — academy 통합 후속, hopenvision.unmong.com 시작페이지를 정본 (allergyinsight 패턴) 수준으로 정리.

## 변경

- 태그라인: \`Type · Subtype\` 형식으로
- Tech Stack: 6 → 13개 (정본 수준 보강)
- 도메인 단일화: \`study.unmong.com\` (6) + \`admin.unmong.com\` (11) → \`hopenvision.unmong.com\` 으로 통일

## 관련 PR (동시 진행)

- bluevlad/unmong-main#? (chore/hopenvision-color-fix) — unmong-main 미러 색상 fix + 동기화
- bluevlad/Claude-Opus-bluevlad#? (chore/study-domain-deprecate) — study.unmong.com 301 redirect

## Test plan

- [x] 정본 (allergyinsight intro.html) 과 패턴 비교 확인
- [ ] PR merge → main → prod 머지 후 https://hopenvision.unmong.com 시각 확인
- [ ] Tech Stack 뱃지 13개 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)