### PR TITLE
feat(landing): / 경로를 GatewayLanding React 컴포넌트로 통합 (Phase B)

### DIFF
--- a/web-user/public/intro.html
+++ b/web-user/public/intro.html
@@ -31,7 +31,7 @@
             <p class="tagline">Admission Prediction · 모의고사 · 합격 예측</p>
             <p class="desc">모의고사 성적 데이터를 기반으로 대학별 합격 가능성을 예측하고, 학습 방향을 제시하는 입시 예측 시스템</p>
             <div class="sl-hero-actions">
-                <a href="https://hopenvision.unmong.com/" target="_blank" rel="noopener" class="sl-btn sl-btn-primary">시험 채점</a>
+                <a href="https://hopenvision.unmong.com/exams" target="_blank" rel="noopener" class="sl-btn sl-btn-primary">시험 채점</a>
                 <a href="https://hopenvision.unmong.com/exams" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">모의고사</a>
                 <a href="https://hopenvision.unmong.com/history" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">응시 이력</a>
                 <a href="https://hopenvision.unmong.com/admin/statistics" target="_blank" rel="noopener" class="sl-btn sl-btn-outline">통계 대시보드</a>
@@ -42,7 +42,7 @@
         <section class="sl-section">
             <div class="sl-section-title">Features</div>
             <div class="sl-features">
-                <a class="sl-feature" href="https://hopenvision.unmong.com/" target="_blank" rel="noopener">
+                <a class="sl-feature" href="https://hopenvision.unmong.com/exams" target="_blank" rel="noopener">
                     <span class="sl-feature-icon">&#128221;</span>
                     <div class="sl-feature-name">시험 채점</div>
                     <div class="sl-feature-desc">OMR/약식 답안 입력 후 즉시 채점 — 과목별 점수와 합격 예측을 한 화면에 표시</div>

--- a/web-user/src/App.tsx
+++ b/web-user/src/App.tsx
@@ -8,6 +8,7 @@ import UserAnswerForm from './pages/UserAnswerForm';
 import UserScoreResult from './pages/UserScoreResult';
 import UserHistory from './pages/UserHistory';
 import MockExamPage from './pages/MockExamPage';
+import GatewayLanding from './pages/GatewayLanding/GatewayLanding';
 import './App.css';
 
 const queryClient = new QueryClient({
@@ -25,8 +26,9 @@ function App() {
       <ConfigProvider locale={koKR}>
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={<UserLayout />}>
-              <Route index element={<UserExamList />} />
+            <Route path="/" element={<GatewayLanding />} />
+            <Route element={<UserLayout />}>
+              <Route path="exams" element={<UserExamList />} />
               <Route path="history" element={<UserHistory />} />
               <Route path="exams/:examCd/answer" element={<UserAnswerForm />} />
               <Route path="exams/:examCd/mock" element={<MockExamPage />} />

--- a/web-user/src/components/UserLayout.tsx
+++ b/web-user/src/components/UserLayout.tsx
@@ -16,7 +16,7 @@ const { Header, Sider, Content } = AntLayout;
 
 const menuItems = [
   {
-    key: '/',
+    key: '/exams',
     icon: <FormOutlined />,
     label: '채점하기',
   },
@@ -61,7 +61,7 @@ export default function UserLayout() {
   const getSelectedKey = () => {
     const path = location.pathname;
     if (path === '/history') return '/history';
-    return '/';
+    return '/exams';
   };
 
   const queryClient = useQueryClient();

--- a/web-user/src/pages/GatewayLanding/GatewayLanding.tsx
+++ b/web-user/src/pages/GatewayLanding/GatewayLanding.tsx
@@ -1,0 +1,158 @@
+import { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import './landing.css';
+
+type FeatureLevel = 'public' | 'admin';
+
+type FeatureCard = {
+  icon: string;
+  name: string;
+  desc: string;
+  to: string;
+  external?: boolean;
+  tag: string;
+  level: FeatureLevel;
+};
+
+const FEATURES: FeatureCard[] = [
+  { icon: '📝', name: '시험 채점', desc: 'OMR/약식 답안 입력 후 즉시 채점 — 과목별 점수와 합격 예측을 한 화면에 표시', to: '/exams', tag: 'Public · Exam', level: 'public' },
+  { icon: '📋', name: '모의고사', desc: '문제세트 기반 온라인 모의고사 응시 — 시간 제한·자동 채점·해설 제공', to: '/exams', tag: 'Public · Mock', level: 'public' },
+  { icon: '📊', name: '응시 이력', desc: '과거 응시 결과·점수 추이·과목별 정답률을 누적 조회', to: '/history', tag: 'Public · History', level: 'public' },
+  { icon: '📋', name: '시험 관리', desc: '시험 회차 등록·수정·답안지 매핑·임포트 진입 통합 (관리자 전용)', to: '/admin/exams', external: true, tag: 'Admin · Exam', level: 'admin' },
+  { icon: '🔑', name: '답안지 등록', desc: '과목·문항별 정답·배점·문제유형(객관식/주관식) 일괄 입력', to: '/admin/exams', external: true, tag: 'Admin · AnswerKey', level: 'admin' },
+  { icon: '📂', name: 'Excel 임포트', desc: '정답표·응시자 명단 Excel 업로드 → 미리보기 → 일괄 저장 (Apache POI)', to: '/admin/import/preview', external: true, tag: 'Admin · Import', level: 'admin' },
+  { icon: '👥', name: '응시자 관리', desc: '응시자 명부·CSV 업로드·임시점수 등록·시험별 응시자 매핑 통합 운영', to: '/admin/applicants', external: true, tag: 'Admin · Applicant', level: 'admin' },
+  { icon: '📈', name: '통계 대시보드', desc: '과목별 평균·합격률·점수 분포 시각화 (Recharts, exam_applicant 기반)', to: '/admin/statistics', external: true, tag: 'Admin · Statistics', level: 'admin' },
+  { icon: '📚', name: '과목 관리', desc: '과목 마스터 코드·명칭·표시 순서 관리 — 시험 등록 시 참조 카탈로그', to: '/admin/subjects', external: true, tag: 'Admin · Master', level: 'admin' },
+  { icon: '🏛️', name: '문제은행', desc: '문항 그룹·문항·정답·해설 등록 + CSV/Excel 일괄 임포트·갱신 지원', to: '/admin/question-bank', external: true, tag: 'Admin · QuestionBank', level: 'admin' },
+  { icon: '📄', name: '문제세트', desc: '문제은행에서 문항을 골라 모의고사용 시험지 세트를 구성·발행', to: '/admin/question-sets', external: true, tag: 'Admin · QuestionSet', level: 'admin' },
+  { icon: '🔍', name: '고시 분석', desc: '공무원 시험 회차·과목별 정답률·난이도·오답 패턴 심층 리포트', to: '/admin/gosi/analytics', external: true, tag: 'Admin · Analytics', level: 'admin' },
+];
+
+const TECH_STACK = [
+  { name: 'React 19', color: '#61dafb' },
+  { name: 'Vite', color: '#646cff' },
+  { name: 'Ant Design', color: '#0170fe' },
+  { name: 'TypeScript', color: '#3178c6' },
+  { name: 'Java 17', color: '#f89820' },
+  { name: 'Spring Boot', color: '#6db33f' },
+  { name: 'JPA · Hibernate', color: '#59666c' },
+  { name: 'Flyway', color: '#cc0000' },
+  { name: 'PostgreSQL', color: '#336791' },
+  { name: 'Redis', color: '#dc382d' },
+  { name: 'Apache POI', color: '#1d6f42' },
+  { name: 'Docker', color: '#2496ed' },
+  { name: 'Nginx', color: '#f97316' },
+];
+
+const CONNECTED_SERVICES = [
+  { name: 'InfraWatcher', role: '컨테이너 모니터링', color: '#06b6d4', href: 'https://infrawatcher.unmong.com/intro.html' },
+  { name: 'QA-Agent', role: '품질 자동 테스트', color: '#8b5cf6', href: 'https://qadashboard.unmong.com/intro.html' },
+  { name: 'StandUp', role: '업무 추적 연동', color: '#14b8a6', href: 'https://standup.unmong.com/intro.html' },
+];
+
+export default function GatewayLanding() {
+  useEffect(() => {
+    document.body.classList.add('is-landing');
+    return () => document.body.classList.remove('is-landing');
+  }, []);
+
+  const renderFeature = (f: FeatureCard) => {
+    const tagClass = f.level === 'admin' ? 'sl-feature-tag sl-feature-tag-admin' : 'sl-feature-tag';
+    const inner = (
+      <>
+        <span className="sl-feature-icon">{f.icon}</span>
+        <div className="sl-feature-name">{f.name}</div>
+        <div className="sl-feature-desc">{f.desc}</div>
+        <span className={tagClass}>{f.tag}</span>
+      </>
+    );
+    if (f.external) {
+      return <a key={f.name} className="sl-feature" href={f.to} target="_blank" rel="noopener noreferrer">{inner}</a>;
+    }
+    return <Link key={f.name} className="sl-feature" to={f.to}>{inner}</Link>;
+  };
+
+  return (
+    <div className="sl-container">
+      <nav className="sl-topnav">
+        <div className="sl-nav-links">
+          <a href="https://www.unmong.com/index.html" className="sl-nav-link"><span className="sl-nav-arrow">↑</span> Portal</a>
+          <a href="https://www.unmong.com/architecture.html" className="sl-nav-link"><span className="sl-nav-arrow">→</span> Architecture</a>
+        </div>
+      </nav>
+
+      <section className="sl-hero">
+        <div className="sl-hero-status"><span className="dot"></span> Active</div>
+        <h1>HopenVision</h1>
+        <p className="tagline">Admission Prediction · 모의고사 · 합격 예측</p>
+        <p className="desc">모의고사 성적 데이터를 기반으로 대학별 합격 가능성을 예측하고, 학습 방향을 제시하는 입시 예측 시스템</p>
+        <div className="sl-hero-actions">
+          <Link to="/exams" className="sl-btn sl-btn-primary">시험 채점</Link>
+          <Link to="/exams" className="sl-btn sl-btn-outline">모의고사</Link>
+          <Link to="/history" className="sl-btn sl-btn-outline">응시 이력</Link>
+          <a href="/admin/statistics" className="sl-btn sl-btn-outline">통계 대시보드</a>
+          <a href="/admin/login" className="sl-btn sl-btn-outline">관리자</a>
+        </div>
+      </section>
+
+      <section className="sl-section">
+        <div className="sl-section-title">Features</div>
+        <div className="sl-features">
+          {FEATURES.map(renderFeature)}
+        </div>
+      </section>
+
+      <section className="sl-section sl-arch">
+        <div className="sl-section-title">Architecture</div>
+        <div className="sl-arch-diagram">
+          <div className="sl-arch-node"><div className="sl-arch-node-label">Frontend</div><div className="sl-arch-node-tech">React</div></div>
+          <div className="sl-arch-arrow">→</div>
+          <div className="sl-arch-node highlight"><div className="sl-arch-node-label">Backend</div><div className="sl-arch-node-tech">Spring Boot</div></div>
+          <div className="sl-arch-arrow">→</div>
+          <div className="sl-arch-node"><div className="sl-arch-node-label">Database</div><div className="sl-arch-node-tech">PostgreSQL</div></div>
+        </div>
+      </section>
+
+      <section className="sl-section sl-flow">
+        <div className="sl-section-title">Service Flow</div>
+        <div className="sl-flow-steps">
+          <div className="sl-flow-step"><div className="sl-flow-step-num">1</div><div className="sl-flow-step-label">시험 응시</div><div className="sl-flow-step-desc">온라인 모의고사</div></div>
+          <div className="sl-flow-arrow">→</div>
+          <div className="sl-flow-step"><div className="sl-flow-step-num">2</div><div className="sl-flow-step-label">성적 분석</div><div className="sl-flow-step-desc">과목별 분석</div></div>
+          <div className="sl-flow-arrow">→</div>
+          <div className="sl-flow-step"><div className="sl-flow-step-num">3</div><div className="sl-flow-step-label">합격 예측</div><div className="sl-flow-step-desc">대학별 가능성</div></div>
+          <div className="sl-flow-arrow">→</div>
+          <div className="sl-flow-step"><div className="sl-flow-step-num">4</div><div className="sl-flow-step-label">통계 리포트</div><div className="sl-flow-step-desc">추이 시각화</div></div>
+        </div>
+      </section>
+
+      <section className="sl-section sl-tech">
+        <div className="sl-section-title">Tech Stack</div>
+        <div className="sl-tech-list">
+          {TECH_STACK.map(t => (
+            <span key={t.name} className="sl-tech-badge">
+              <span className="sl-tech-dot" style={{ background: t.color }}></span> {t.name}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <section className="sl-section sl-connected">
+        <div className="sl-section-title">Connected Services</div>
+        <div className="sl-connected-grid">
+          {CONNECTED_SERVICES.map(svc => (
+            <a key={svc.name} href={svc.href} target="_blank" rel="noopener noreferrer" className="sl-connected-card">
+              <span className="sl-connected-dot" style={{ background: svc.color }}></span>
+              <div className="sl-connected-info">
+                <div className="sl-connected-name">{svc.name}</div>
+                <div className="sl-connected-role">{svc.role}</div>
+              </div>
+              <span className="sl-connected-arrow">→</span>
+            </a>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web-user/src/pages/GatewayLanding/landing.css
+++ b/web-user/src/pages/GatewayLanding/landing.css
@@ -1,0 +1,554 @@
+/* GatewayLanding 활성화 시에만 적용 (App 에서 body.is-landing 토글). 다른 SPA 페이지에는 영향 없음. */
+body.is-landing {
+    --bg-color: #0f172a;
+    --card-bg: rgba(30, 41, 59, 0.85);
+    --card-bg-hover: rgba(30, 41, 59, 0.95);
+    --text-color: #e2e8f0;
+    --text-muted: #94a3b8;
+    --text-dim: #64748b;
+    --accent-color: #3b82f6;
+    --border-color: rgba(148, 163, 184, 0.15);
+    --service-color: #3b82f6;
+    --glow-r: 59;
+    --glow-g: 130;
+    --glow-b: 246;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: var(--bg-color);
+    color: var(--text-color);
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+body.is-landing * { margin: 0; padding: 0; box-sizing: border-box; }
+
+body.is-landing::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background-image:
+        linear-gradient(rgba(148, 163, 184, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(148, 163, 184, 0.03) 1px, transparent 1px);
+    background-size: 40px 40px;
+    pointer-events: none;
+}
+
+body.is-landing::after {
+    content: '';
+    position: fixed;
+    inset: -50%;
+    width: 200%;
+    height: 200%;
+    background:
+        radial-gradient(ellipse at 30% 10%, rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.08) 0%, transparent 50%),
+        radial-gradient(ellipse at 70% 90%, rgba(139, 92, 246, 0.05) 0%, transparent 50%);
+    pointer-events: none;
+}
+
+.sl-container {
+    position: relative;
+    z-index: 1;
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 2rem 2rem 3rem;
+}
+
+/* ── Navigation ── */
+.sl-topnav {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    margin-bottom: 2rem;
+    animation: fadeInDown 0.6s ease-out;
+}
+
+.sl-nav-links {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.sl-nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    color: var(--text-muted);
+    text-decoration: none;
+    font-size: 0.8rem;
+    font-weight: 500;
+    padding: 0.35rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-color);
+    transition: all 0.2s;
+}
+
+.sl-nav-link:hover {
+    color: #fff;
+    border-color: var(--service-color);
+    background: rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.1);
+}
+
+.sl-nav-arrow {
+    font-weight: 400;
+    opacity: 0.7;
+}
+
+/* ── Hero ── */
+.sl-hero {
+    text-align: center;
+    padding: 2.5rem 1.5rem;
+    margin-bottom: 2rem;
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    background: var(--card-bg);
+    position: relative;
+    overflow: hidden;
+    animation: fadeInUp 0.7s ease-out 0.1s backwards;
+}
+
+.sl-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, var(--service-color), transparent);
+}
+
+.sl-hero-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.2rem 0.65rem;
+    border-radius: 9999px;
+    margin-bottom: 1rem;
+    color: #22c55e;
+    background: rgba(34, 197, 94, 0.1);
+}
+
+.sl-hero-status .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #22c55e;
+    animation: pulse 2s ease-in-out infinite;
+}
+
+.sl-hero h1 {
+    font-size: 2.2rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    margin-bottom: 0.3rem;
+    color: #f1f5f9;
+}
+
+.sl-hero .tagline {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    font-weight: 300;
+    margin-bottom: 0.4rem;
+}
+
+.sl-hero .desc {
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    max-width: 560px;
+    margin: 0 auto 1.5rem;
+    line-height: 1.6;
+}
+
+.sl-hero-actions {
+    display: flex;
+    justify-content: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.sl-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.5rem 1.1rem;
+    border-radius: 8px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: all 0.2s;
+    border: 1px solid transparent;
+}
+
+.sl-btn-primary {
+    background: var(--service-color);
+    color: #fff;
+}
+
+.sl-btn-primary:hover {
+    filter: brightness(1.15);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.3);
+}
+
+.sl-btn-outline {
+    border-color: var(--border-color);
+    color: var(--text-muted);
+    background: transparent;
+}
+
+.sl-btn-outline:hover {
+    border-color: var(--service-color);
+    color: #fff;
+    background: rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.08);
+}
+
+/* ── Section titles ── */
+.sl-section {
+    margin-bottom: 1.75rem;
+}
+
+.sl-section-title {
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--service-color);
+    margin-bottom: 0.85rem;
+    padding-left: 0.6rem;
+    border-left: 2px solid var(--service-color);
+}
+
+/* ── Features Grid ── */
+.sl-features {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.85rem;
+    animation: fadeInUp 0.7s ease-out 0.2s backwards;
+}
+
+.sl-feature {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1rem;
+    transition: all 0.25s;
+    text-decoration: none;
+    display: block;
+    cursor: pointer;
+}
+
+.sl-feature:hover {
+    background: var(--card-bg-hover);
+    border-color: rgba(148, 163, 184, 0.25);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px -6px rgba(0, 0, 0, 0.3);
+}
+
+.sl-feature-icon {
+    font-size: 1.4rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.sl-feature-name {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin-bottom: 0.25rem;
+}
+
+.sl-feature-desc {
+    font-size: 0.7rem;
+    color: var(--text-dim);
+    line-height: 1.4;
+}
+
+.sl-feature-tag {
+    display: inline-block;
+    margin-top: 0.5rem;
+    font-size: 0.6rem;
+    font-weight: 600;
+    padding: 0.15rem 0.45rem;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    background: rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.1);
+    color: var(--service-color);
+}
+
+/* ── Architecture Diagram ── */
+.sl-arch {
+    animation: fadeInUp 0.7s ease-out 0.3s backwards;
+}
+
+.sl-arch-diagram {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    flex-wrap: wrap;
+}
+
+.sl-arch-node {
+    text-align: center;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: rgba(15, 23, 42, 0.6);
+    min-width: 100px;
+}
+
+.sl-arch-node-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin-bottom: 0.2rem;
+}
+
+.sl-arch-node-tech {
+    font-size: 0.6rem;
+    color: var(--text-dim);
+}
+
+.sl-arch-node.highlight {
+    border-color: var(--service-color);
+    box-shadow: 0 0 12px rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.15);
+}
+
+.sl-arch-arrow {
+    padding: 0 0.6rem;
+    color: var(--text-dim);
+    font-size: 1rem;
+}
+
+/* ── Flow Diagram ── */
+.sl-flow {
+    animation: fadeInUp 0.7s ease-out 0.35s backwards;
+}
+
+.sl-flow-steps {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0;
+    overflow-x: auto;
+}
+
+.sl-flow-step {
+    text-align: center;
+    flex-shrink: 0;
+    padding: 0.6rem 0.8rem;
+}
+
+.sl-flow-step-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: rgba(var(--glow-r, 59), var(--glow-g, 130), var(--glow-b, 246), 0.15);
+    color: var(--service-color);
+    font-size: 0.65rem;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+}
+
+.sl-flow-step-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: #f1f5f9;
+    margin-bottom: 0.15rem;
+    white-space: nowrap;
+}
+
+.sl-flow-step-desc {
+    font-size: 0.6rem;
+    color: var(--text-dim);
+    white-space: nowrap;
+}
+
+.sl-flow-arrow {
+    flex-shrink: 0;
+    color: var(--text-dim);
+    font-size: 0.85rem;
+    padding: 0 0.3rem;
+    opacity: 0.5;
+}
+
+/* ── Tech Stack ── */
+.sl-tech {
+    animation: fadeInUp 0.7s ease-out 0.4s backwards;
+}
+
+.sl-tech-list {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.sl-tech-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.4rem 0.75rem;
+    border-radius: 8px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    transition: border-color 0.2s;
+}
+
+.sl-tech-badge:hover {
+    border-color: rgba(148, 163, 184, 0.3);
+}
+
+.sl-tech-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+}
+
+/* ── Connected Services ── */
+.sl-connected {
+    animation: fadeInUp 0.7s ease-out 0.45s backwards;
+}
+
+.sl-connected-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 0.7rem;
+}
+
+.sl-connected-card {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    text-decoration: none;
+    transition: all 0.2s;
+}
+
+.sl-connected-card:hover {
+    background: var(--card-bg-hover);
+    border-color: rgba(148, 163, 184, 0.25);
+    transform: translateY(-1px);
+}
+
+.sl-connected-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.sl-connected-info { flex: 1; }
+
+.sl-connected-name {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: #f1f5f9;
+}
+
+.sl-connected-role {
+    font-size: 0.62rem;
+    color: var(--text-dim);
+}
+
+.sl-connected-arrow {
+    color: var(--text-dim);
+    font-size: 0.8rem;
+    transition: color 0.2s;
+}
+
+.sl-connected-card:hover .sl-connected-arrow {
+    color: var(--service-color);
+}
+
+/* ── Footer ── */
+.sl-footer {
+    margin-top: 2.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border-color);
+    animation: fadeInUp 0.7s ease-out 0.5s backwards;
+}
+
+.sl-footer-inner {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    padding: 0.85rem 1.15rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.sl-footer-left {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.sl-footer-logo {
+    width: 32px;
+    height: 32px;
+    border-radius: 6px;
+}
+
+.sl-footer-text {
+    font-size: 0.68rem;
+    color: var(--text-dim);
+}
+
+.sl-footer-copy {
+    font-size: 0.6rem;
+    color: var(--text-dim);
+}
+
+/* ── Animations ── */
+@keyframes fadeInDown {
+    from { opacity: 0; transform: translateY(-16px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeInUp {
+    from { opacity: 0; transform: translateY(16px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+    .sl-container { padding: 1.5rem 1rem 2rem; }
+    .sl-hero h1 { font-size: 1.6rem; }
+    .sl-hero { padding: 1.75rem 1rem; }
+    .sl-features { grid-template-columns: repeat(2, 1fr); }
+    .sl-arch-diagram { flex-direction: column; gap: 0; }
+    .sl-arch-arrow { transform: rotate(90deg); padding: 0.3rem 0; }
+    .sl-topnav { flex-direction: column; gap: 0.5rem; align-items: flex-start; }
+}
+
+@media (max-width: 480px) {
+    .sl-features { grid-template-columns: 1fr; }
+    .sl-connected-grid { grid-template-columns: 1fr; }
+    .sl-flow-steps { padding: 1rem; }
+    .sl-hero-actions { flex-direction: column; align-items: center; }
+}

--- a/web-user/src/pages/MockExamPage.tsx
+++ b/web-user/src/pages/MockExamPage.tsx
@@ -278,7 +278,7 @@ const MockExamPage: React.FC = () => {
   }, []);
 
   const handleSubjectCancel = useCallback(() => {
-    navigate('/');
+    navigate('/exams');
   }, [navigate]);
 
   const handleAnswerSelect = (questionNo: number, answer: string) => {
@@ -356,7 +356,7 @@ const MockExamPage: React.FC = () => {
             reviewMode,
           });
         }
-        navigate('/');
+        navigate('/exams');
       },
     });
   };
@@ -416,7 +416,7 @@ const MockExamPage: React.FC = () => {
     return (
       <div style={{ padding: 24 }}>
         <Alert message="시험 정보를 불러올 수 없습니다" type="error" showIcon />
-        <Button style={{ marginTop: 16 }} icon={<ArrowLeftOutlined />} onClick={() => navigate('/')}>목록으로</Button>
+        <Button style={{ marginTop: 16 }} icon={<ArrowLeftOutlined />} onClick={() => navigate('/exams')}>목록으로</Button>
       </div>
     );
   }
@@ -426,7 +426,7 @@ const MockExamPage: React.FC = () => {
       <div style={{ padding: 24 }}>
         <Alert message="이미 채점이 완료된 시험입니다" type="info" showIcon />
         <Space style={{ marginTop: 16 }}>
-          <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/')}>목록으로</Button>
+          <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/exams')}>목록으로</Button>
           <Button type="primary" onClick={() => navigate(`/exams/${examCd}/result`)}>결과 보기</Button>
         </Space>
       </div>

--- a/web-user/src/pages/UserAnswerForm.tsx
+++ b/web-user/src/pages/UserAnswerForm.tsx
@@ -73,7 +73,7 @@ const UserAnswerForm: React.FC = () => {
   }, []);
 
   const handleSubjectCancel = useCallback(() => {
-    navigate('/');
+    navigate('/exams');
   }, [navigate]);
 
   const effectiveActiveTab = activeTab || (activeSubjects[0]?.subjectCd ?? '');
@@ -206,7 +206,7 @@ const UserAnswerForm: React.FC = () => {
         <Button
           style={{ marginTop: 16 }}
           icon={<ArrowLeftOutlined />}
-          onClick={() => navigate('/')}
+          onClick={() => navigate('/exams')}
         >
           목록으로
         </Button>
@@ -224,7 +224,7 @@ const UserAnswerForm: React.FC = () => {
           showIcon
         />
         <Space style={{ marginTop: 16 }}>
-          <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/')}>
+          <Button icon={<ArrowLeftOutlined />} onClick={() => navigate('/exams')}>
             목록으로
           </Button>
           <Button type="primary" onClick={() => navigate(`/exams/${examCd}/result`)}>
@@ -291,7 +291,7 @@ const UserAnswerForm: React.FC = () => {
           <div>
             <Button
               icon={<ArrowLeftOutlined />}
-              onClick={() => navigate('/')}
+              onClick={() => navigate('/exams')}
               style={{ marginBottom: 16 }}
             >
               목록으로

--- a/web-user/src/pages/UserScoreResult.tsx
+++ b/web-user/src/pages/UserScoreResult.tsx
@@ -109,7 +109,7 @@ const UserScoreResult: React.FC = () => {
         <Button
           style={{ marginTop: 16 }}
           icon={<ArrowLeftOutlined />}
-          onClick={() => navigate('/')}
+          onClick={() => navigate('/exams')}
         >
           목록으로
         </Button>
@@ -556,7 +556,7 @@ const UserScoreResult: React.FC = () => {
         <div style={{ marginBottom: 24 }}>
           <Button
             icon={<ArrowLeftOutlined />}
-            onClick={() => navigate('/')}
+            onClick={() => navigate('/exams')}
             style={{ marginBottom: 16 }}
           >
             목록으로


### PR DESCRIPTION
## Summary

PR #482 에서 정적 intro.html 의 도메인 통일(Phase A)까지만 처리되었고, **SERVICE_LANDING_GUIDE.md §3** 의 React 라우터 통합(Phase B)이 미완이라 \`https://hopenvision.unmong.com/\` 진입 시 통합 소개가 아닌 SPA 가 직접 노출되는 문제가 있었음.

본 PR 로 정본 패턴(allergyinsight) 대로 React 게이트웨이 컴포넌트를 통합.

## 변경

- \`web-user/src/pages/GatewayLanding/\` 신설
  - \`GatewayLanding.tsx\` — 5섹션 (Hero / Features / Architecture / Service Flow / Tech Stack / Connected Services)
  - \`landing.css\` — \`service-landing.css\` 복사 후 \`body.is-landing\` 으로 스코핑 (다른 SPA 페이지 영향 없음)
- \`App.tsx\` — \`/\` → \`<GatewayLanding />\`, SPA 진입점은 \`/exams\`
- \`UserLayout\` — "채점하기" 메뉴 key \`/\` → \`/exams\`, active 판정 보정
- SPA 페이지의 \`navigate('/')\` (10곳) → \`navigate('/exams')\` 일괄 변경
- \`intro.html\` "시험 채점" 버튼 도메인도 \`/exams\` 로 보정 (외부 직접 접근 시 무한루프 방지)

## 동작

| URL | 동작 |
|---|---|
| \`https://hopenvision.unmong.com/\` | **통합 소개 페이지** (GatewayLanding) ← 본 PR 의 효과 |
| \`https://hopenvision.unmong.com/exams\` | 기존 시험 채점 SPA |
| \`https://hopenvision.unmong.com/history\` | 응시 이력 |
| \`https://hopenvision.unmong.com/admin/...\` | admin SPA (변경 없음) |

## 후속 (별도 PR)

- 권한 잠금 + 토스트 시스템 — web-user 에 AuthContext 가 없으므로 정적 라벨만 표시. 통합 인증 도입 시 추가.

## Test plan

- [x] \`npm run build:user\` 성공 (TS + Vite)
- [x] \`docker compose -f docker-compose.prod.yml build hopenvision-web\` 성공
- [ ] PR merge → main → prod → 자동 배포 후 \`https://hopenvision.unmong.com/\` 시각 확인
- [ ] \`/exams\` 진입 → 시험 목록 정상
- [ ] 메뉴에서 "채점하기" 클릭 시 \`/exams\` 로 이동
- [ ] 시험 응시 후 "목록으로" 버튼 → \`/exams\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)