### PR TITLE
ci: P3-α — fix-results 등록 + prod→main 자동 동기화 워크플로우 도입

### DIFF
--- a/.github/workflows/register-fix-to-dashboard.yml
+++ b/.github/workflows/register-fix-to-dashboard.yml
@@ -1,0 +1,109 @@
+# ==============================================================
+# fix 커밋 → QA Dashboard 자동 등록 (developer 경로)
+# 표준: standards/qa/FIX_RESULT_REGISTRATION.md
+#
+# 적용 대상: 모든 서비스 repo (main↔prod 운영 여부 무관)
+# 도입 절차:
+#   1) 이 파일을 .github/workflows/register-fix-to-dashboard.yml 로 복사
+#   2) repo Secrets 등록:
+#      - QA_DASHBOARD_API_URL  (예: https://qadashboard.unmong.com/api)
+#      - QA_DASHBOARD_API_KEY  (QA-Dashboard 운영자 발급)
+#   3) CLAUDE.md 의 fix 커밋 표준에 Discovery-Method 필수 명시
+#      (또는 표준 PROD_TO_MAIN_AUTO_SYNC 와 함께 루트 CLAUDE.md 한 곳에서 강제)
+#
+# 동작:
+#   - main 또는 prod 에 fix 로 시작하는 커밋이 push 되면 트리거
+#   - footer 메타데이터 (Discovery-Method, Root-Cause 등) 파싱
+#   - QA Dashboard /api/fix-results 에 fix_source='developer' 로 POST
+#   - footer 누락 시 ::warning:: 만 남기고 등록 스킵 (push 자체는 막지 않음)
+#
+# Claude 보조 여부 자동 판별:
+#   - Co-Authored-By 트레일러에 "Claude" 가 있으면 strategy = manual-dev-claude-assisted
+#   - 없으면 strategy = manual-dev
+# ==============================================================
+name: Register fix to QA Dashboard
+
+on:
+  push:
+    branches: [main, prod]
+
+jobs:
+  register-fix:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.head_commit.message, 'fix')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Parse fix commit footer & POST to QA Dashboard
+        env:
+          QA_DASHBOARD_API_URL: ${{ secrets.QA_DASHBOARD_API_URL }}
+          QA_DASHBOARD_API_KEY: ${{ secrets.QA_DASHBOARD_API_KEY }}
+          PROJECT_NAME: ${{ github.event.repository.name }}
+          COMMIT_HASH:  ${{ github.event.head_commit.id }}
+          AUTHOR_EMAIL: ${{ github.event.head_commit.author.email }}
+        run: |
+          set -euo pipefail
+          MSG=$(git log -1 --pretty=%B "$COMMIT_HASH")
+
+          extract() {
+            echo "$MSG" | awk -v k="$1" 'BEGIN{IGNORECASE=1} $0 ~ "^"k":" {sub("^"k": *",""); print; exit}'
+          }
+
+          DISCOVERY=$(extract "Discovery-Method")
+          ROOTCAUSE=$(extract "Root-Cause")
+          CATEGORY=$(extract "Error-Category")
+          LAYER=$(extract "Affected-Layer")
+          RECURRENCE=$(extract "Recurrence")
+          PREVENTION=$(extract "Prevention")
+
+          # Discovery-Method 또는 Root-Cause 누락 시 등록 스킵 (footer 표준 미준수)
+          if [ -z "$DISCOVERY" ] || [ -z "$ROOTCAUSE" ]; then
+            echo "::warning::fix 커밋이지만 footer 메타데이터 부재 — 등록 스킵 (commit=$COMMIT_HASH)"
+            echo "::warning::필수 footer: Discovery-Method, Root-Cause, Error-Category, Prevention"
+            exit 0
+          fi
+
+          # Claude-assisted 여부는 Co-Authored-By 트레일러로 판별
+          STRATEGY=$(echo "$MSG" | grep -qi "Co-Authored-By:.*Claude" && echo "manual-dev-claude-assisted" || echo "manual-dev")
+
+          # subject 의 첫 줄 → error 요약
+          SUBJECT=$(echo "$MSG" | head -1)
+
+          PAYLOAD=$(jq -n \
+            --arg project "$PROJECT_NAME" \
+            --arg commit  "$COMMIT_HASH" \
+            --arg actor   "$AUTHOR_EMAIL" \
+            --arg disc    "$DISCOVERY" \
+            --arg cat     "$ROOTCAUSE" \
+            --arg layer   "$LAYER" \
+            --arg recur   "${RECURRENCE:-first}" \
+            --arg prev    "$PREVENTION" \
+            --arg strat   "$STRATEGY" \
+            --arg err     "$SUBJECT" \
+            '{
+              projectName:      $project,
+              issueNumber:      null,
+              fixSource:        "developer",
+              discoveryMethod:  $disc,
+              actor:            $actor,
+              sourceRunId:      null,
+              priority:         "P2",
+              category:         $cat,
+              affectedLayer:    $layer,
+              strategy:         $strat,
+              status:           "deployed",
+              commitHash:       $commit,
+              recurrence:       $recur,
+              preventionRule:   $prev,
+              error:            $err,
+              completedAt:      now | todate
+            }')
+
+          curl -fsSL -X POST "$QA_DASHBOARD_API_URL/fix-results" \
+            -H "Authorization: Bearer $QA_DASHBOARD_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"
+
+          echo "::notice::fix commit registered to QA Dashboard (commit=$COMMIT_HASH, source=developer, strategy=$STRATEGY)"

--- a/.github/workflows/sync-prod-to-main.yml
+++ b/.github/workflows/sync-prod-to-main.yml
@@ -1,0 +1,141 @@
+# ==============================================================
+# Prod → Main 자동 동기화 (cherry-pick 기반)
+# 표준: standards/git/PROD_TO_MAIN_AUTO_SYNC.md
+#
+# 적용 대상: main ↔ prod 이중 브랜치 운영 서비스 repo
+# 도입 절차:
+#   1) 이 파일을 .github/workflows/sync-prod-to-main.yml 로 복사
+#   2) repo Secrets 에 SYNC_PAT 등록 (fine-grained PAT, contents+PR write)
+#   3) (선택) main branch protection bypass actors 에 PAT 소유자 추가
+# ==============================================================
+name: Sync prod-only commits back to main
+
+on:
+  push:
+    branches: [prod]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # 자기 자신이 만든 main push 가 만든 prod push 에는 재진입 안 함 (안전 가드)
+    if: github.actor != 'prod-sync-bot' && !contains(github.event.head_commit.message, '[skip-sync]')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SYNC_PAT }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "prod-sync-bot"
+          git config user.email "prod-sync-bot@unmong.com"
+          git fetch origin main prod
+
+      - name: Detect prod-only commits not yet on main
+        id: detect
+        run: |
+          set -euo pipefail
+          # 1) prod 에만 있는 non-merge commit hash 추출
+          PROD_ONLY=$(git log --no-merges --pretty=%H origin/main..origin/prod)
+          if [ -z "$PROD_ONLY" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::no prod-only non-merge commits, nothing to sync"
+            exit 0
+          fi
+
+          # 2) main 의 최근 non-merge commit 들 patch-id 사전 (lookback 300)
+          MAIN_PIDS=$(git log -300 --no-merges --pretty=%H origin/main | \
+            while read m; do
+              git show "$m" 2>/dev/null | git patch-id 2>/dev/null | awk '{print $1}'
+            done | sort -u)
+
+          # 3) 각 prod-only commit 검사:
+          #    (a) main commit message 에 'cherry picked from commit <hash>' trail 이 있으면 skip
+          #    (b) patch-id 가 main 사전에 있으면 skip
+          #    (c) 둘 다 없으면 cherry-pick 대상
+          NEED=""
+          while IFS= read -r c; do
+            [ -z "$c" ] && continue
+
+            # (a) cherry-pick(-x) trail
+            if git log origin/main --grep="cherry picked from commit $c" --pretty=%H | head -1 | grep -q .; then
+              echo "::notice::skip $c (already on main via cherry-pick -x trail)"
+              continue
+            fi
+
+            # (b) patch-id 비교
+            PID=$(git show "$c" 2>/dev/null | git patch-id 2>/dev/null | awk '{print $1}')
+            if [ -n "$PID" ] && echo "$MAIN_PIDS" | grep -Fxq "$PID"; then
+              echo "::notice::skip $c (patch-id match found in main lookback)"
+              continue
+            fi
+
+            NEED="${NEED}${c}"$'\n'
+          done <<< "$PROD_ONLY"
+
+          if [ -z "${NEED//[$'\n ']/}" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::all prod-only commits already represented on main, nothing to sync"
+            exit 0
+          fi
+
+          printf '%s' "$NEED" > /tmp/commits.txt
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::will cherry-pick $(grep -c . /tmp/commits.txt) commit(s) to main"
+          cat /tmp/commits.txt
+
+      - name: Cherry-pick to main, push (with rebase retry on race)
+        if: steps.detect.outputs.skip == 'false'
+        id: pick
+        run: |
+          set -euo pipefail
+          git checkout main
+          git pull --ff-only origin main
+
+          while IFS= read -r commit; do
+            [ -z "$commit" ] && continue
+            # --empty=drop: 동일 내용이지만 base tree 차이로 patch-id 가 다른 commit 도 안전 처리
+            if ! git cherry-pick -x --empty=drop "$commit"; then
+              echo "::warning::cherry-pick failed for $commit — falling back to PR"
+              git cherry-pick --abort || true
+              echo "fallback=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done < /tmp/commits.txt
+
+          # main 동시 push race 대비: 최대 3회 rebase 후 재시도
+          for i in 1 2 3; do
+            if git push origin main; then
+              echo "fallback=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::pushed cherry-picked commits to main (attempt $i)"
+              exit 0
+            fi
+            echo "::warning::push failed (attempt $i), rebasing and retrying"
+            git pull --rebase origin main
+          done
+          echo "::error::push to main failed after 3 retries"
+          exit 1
+
+      - name: Fallback — open PR for manual merge
+        if: steps.pick.outputs.fallback == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+        run: |
+          set -euo pipefail
+          BRANCH="auto-sync/prod-to-main-$(date -u +%Y%m%d-%H%M%S)"
+          git checkout origin/main -b "$BRANCH"
+          # 충돌 마커 포함한 채로 commit 하면 PR 에서 충돌 명확히 보임
+          git merge --no-edit origin/prod || {
+            git add -A
+            git commit -m "WIP: merge conflict, resolve manually" || true
+          }
+          git push origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Auto-sync: prod → main (수동 해결 필요)" \
+            --body "prod 직접 커밋을 cherry-pick 하다 충돌 발생. 표준: \`standards/git/PROD_TO_MAIN_AUTO_SYNC.md\`. 리뷰어가 충돌 해결 후 머지해주세요."


### PR DESCRIPTION
## 개요

표준 P3-α 일괄 도입. main 직접 push 가 protection 으로 막혀있어 PR 경유.

## 추가 워크플로우

- `.github/workflows/register-fix-to-dashboard.yml` — fix 커밋 footer 파싱 → POST /api/fix-results (fix_source='developer')
- `.github/workflows/sync-prod-to-main.yml` — prod push 시 prod-only 커밋을 main 으로 자동 cherry-pick(-x)

## Secrets (등록 완료)

- `QA_DASHBOARD_API_KEY`
- `QA_DASHBOARD_API_URL`
- `SYNC_PAT`

## 표준

- standards/qa/FIX_RESULT_REGISTRATION.md
- standards/git/PROD_TO_MAIN_AUTO_SYNC.md

## 참고

prod 에는 이미 `33044f8` 로 동일 변경 반영됨. 이 PR 머지 시 main 도 정합성 회복.

🤖 Generated with [Claude Code](https://claude.com/claude-code)